### PR TITLE
Fix outage time step bugs

### DIFF
--- a/src/core/prodfactor.jl
+++ b/src/core/prodfactor.jl
@@ -326,7 +326,7 @@ function prodfactor(chp::AbstractCHP, year::Int=2017, outage_start_time_step::In
     prod_factor = [1.0 - unavailability_hourly[i] for i in 1:8760 for _ in 1:ts_per_hour]
 
     # Ignore unavailability in timestep if it intersects with an outage interval
-    if outage_end_time_step - outage_start_time_step >= 1
+    if outage_start_time_step != 0 && outage_end_time_step != 0
         prod_factor[outage_start_time_step:outage_end_time_step] .= ones(outage_end_time_step - outage_start_time_step + 1)
     end
 

--- a/src/core/reopt_inputs.jl
+++ b/src/core/reopt_inputs.jl
@@ -578,7 +578,7 @@ and critical_loads_kw respectively.
 """
 function setup_electric_utility_inputs(s::AbstractScenario)
     if s.electric_utility.outage_end_time_step > 0 &&
-            s.electric_utility.outage_end_time_step > s.electric_utility.outage_start_time_step
+            s.electric_utility.outage_end_time_step >= s.electric_utility.outage_start_time_step
         time_steps_without_grid = Int[i for i in range(s.electric_utility.outage_start_time_step,
                                                     stop=s.electric_utility.outage_end_time_step)]
         if s.electric_utility.outage_start_time_step > 1


### PR DESCRIPTION
When creating the CHP production factor, to check if an outage is being modeled, we're testing if the difference between outage start and end time steps is >= 1. This is incorrect because a difference of zero would just be a 1 tilmestep outage. I have changed the if statement to check if the outage start and end times are non zero (zero is not a valid time step so it represents no outage).
Also, when creating the time steps with and without grid inputs, we're checking if outage end > outage start. I have changed this to >= because again start and end can be equal.