### PR TITLE
Fix urdb fixed charge and wind default overwrite bugs

### DIFF
--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -525,10 +525,8 @@ function parse_urdb_fixed_charges(d::Dict)
     min_monthly = 0.0
 
     # first try $/month, then check if $/day exists, as of 1/28/2020 there were only $/day and $month entries in the URDB
-    fixed_monthly = get(d, "fixedmonthlycharge", nothing)
-    if !isnothing(fixed_monthly)
-        fixed_monthly = Float64(fixed_monthly)
-    else
+    fixed_monthly = Float64(get(d, "fixedmonthlycharge", 0.0))
+    if fixed_monthly == 0.0
         if get(d, "fixedchargeunits", "") == "\$/month" 
             fixed_monthly = Float64(get(d, "fixedchargefirstmeter", 0.0))
         elseif get(d, "fixedchargeunits", "") == "\$/day"

--- a/src/core/wind.jl
+++ b/src/core/wind.jl
@@ -35,7 +35,7 @@ struct with inner constructor:
 function Wind(;
     min_kw = 0.0,
     max_kw = 1.0e9,
-    installed_cost_per_kw = 0.0,
+    installed_cost_per_kw = missing,
     om_cost_per_kw = 35.0,
     prod_factor_series = missing,
     size_class = "",
@@ -46,7 +46,7 @@ function Wind(;
     macrs_option_years = 5,
     macrs_bonus_pct = 0.0,
     macrs_itc_reduction = 0.5,
-    federal_itc_pct = 0.26,
+    federal_itc_pct = missing,
     federal_rebate_per_kw = 0.0,
     state_ibi_pct = 0.0,
     state_ibi_max = 1.0e10,
@@ -68,7 +68,7 @@ function Wind(;
 
 `size_class` must be one of ["residential", "commercial", "medium", "large"]. If `size_class` is not provided then it is determined based on the average electric load.
 
-If no `installed_cost_per_kw` is provided (or it is 0.0) then it is determined from:
+If no `installed_cost_per_kw` is provided then it is determined from:
 ```julia
 size_class_to_installed_cost = Dict(
     "residential"=> 11950.0,
@@ -101,7 +101,7 @@ These values are passed to SAM to get the turbine production factor.
 struct Wind <: AbstractTech
     min_kw::Float64
     max_kw::Float64
-    installed_cost_per_kw::Float64
+    installed_cost_per_kw::Union{Missing, Float64}
     om_cost_per_kw::Float64
     prod_factor_series::Union{Missing, Array{Real,1}}
     size_class::String
@@ -113,7 +113,7 @@ struct Wind <: AbstractTech
     macrs_option_years::Int
     macrs_bonus_pct::Float64
     macrs_itc_reduction::Float64
-    federal_itc_pct::Float64
+    federal_itc_pct::Union{Missing, Float64}
     federal_rebate_per_kw::Float64
     state_ibi_pct::Float64
     state_ibi_max::Float64
@@ -135,7 +135,7 @@ struct Wind <: AbstractTech
     function Wind(;
         min_kw = 0.0,
         max_kw = 1.0e9,
-        installed_cost_per_kw = 0.0,
+        installed_cost_per_kw = missing,
         om_cost_per_kw = 35.0,
         prod_factor_series = missing,
         size_class = "",
@@ -146,7 +146,7 @@ struct Wind <: AbstractTech
         macrs_option_years = 5,
         macrs_bonus_pct = 0.0,
         macrs_itc_reduction = 0.5,
-        federal_itc_pct = 0.26,
+        federal_itc_pct = missing,
         federal_rebate_per_kw = 0.0,
         state_ibi_pct = 0.0,
         state_ibi_max = 1.0e10,
@@ -200,11 +200,11 @@ struct Wind <: AbstractTech
             @error "Wind.size_class must be one of $(keys(size_class_to_hub_height))"
         end
 
-        if installed_cost_per_kw == 0.0
+        if ismissing(installed_cost_per_kw)
             installed_cost_per_kw = size_class_to_installed_cost[size_class]
         end
 
-        if federal_itc_pct == 0.3
+        if ismissing(federal_itc_pct)
             federal_itc_pct = size_class_to_itc_incentives[size_class]
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,7 +138,7 @@ else  # run HiGHS tests
             "output_flag" => false, "log_to_console" => false)
         )
         results = run_reopt(model, "./scenarios/incentives.json")
-        @test results["Financial"]["lcc"] ≈ 1.094596365e7 atol=1e4  
+        @test results["Financial"]["lcc"] ≈ 1.096852612e7 atol=1e4  
     end
 
     try


### PR DESCRIPTION
Wind
 - Existing behavior: If the user provides 0.0 for installed_cost_per_kw or 0.3 for federal_itc_pct in their Wind inputs, these get overwritten with no warning based on size_class. 
 - New behavior: Defaults for Wind installed_cost_per_kw and federal_itc_pct now = missing. Only if these arguments are missing are they overwritten based on size_class. 
Fixed charges
 - Existing behavior: The urdb_response field fixedmonthlycharges is ignored with no warning. Only fixedchargefirstmeter is handled.
 - New behavior: The value of urdb_response field fixedmonthlycharges is included in the tariff model if present and non zero. Otherwise value of urdb_response field fixedchargefirstmeter (along with fixedchargeunits) is included if present.