### PR TITLE
Correct dvFuelUsage unit inconsistency

### DIFF
--- a/src/REopt.jl
+++ b/src/REopt.jl
@@ -64,6 +64,13 @@ using ArchGDAL
 using Roots: fzero  # for IRR
 global hdl = nothing
 
+const M3_TO_GAL = 264.172  # [gal/m^3]
+const GAL_DIESEL_TO_KWH = 40.7  # [kWh/gal_diesel]
+const MMBTU_TO_KWH = 293.07107  # [kWh/mmbtu]
+const TONHOUR_TO_KWH_THERMAL = 3.51685
+const EXISTING_BOILER_EFFICIENCY = 0.8
+const TONNES_TO_LBS = 2204.62  # [lb/tonne]
+
 include("keys.jl")
 include("core/types.jl")
 include("core/utils.jl")

--- a/src/REopt.jl
+++ b/src/REopt.jl
@@ -64,12 +64,13 @@ using ArchGDAL
 using Roots: fzero  # for IRR
 global hdl = nothing
 
-const M3_TO_GAL = 264.172  # [gal/m^3]
-const GAL_DIESEL_TO_KWH = 40.7  # [kWh/gal_diesel]
-const MMBTU_TO_KWH = 293.07107  # [kWh/mmbtu]
-const TONHOUR_TO_KWH_THERMAL = 3.51685
 const EXISTING_BOILER_EFFICIENCY = 0.8
-const TONNES_TO_LBS = 2204.62  # [lb/tonne]
+
+const GAL_PER_M3 = 264.172  # [gal/m^3]
+const KWH_PER_GAL_DIESEL = 40.7  # [kWh/gal_diesel]
+const KWH_PER_MMBTU = 293.07107  # [kWh/mmbtu]
+const KWH_THERMAL_PER_TONHOUR = 3.51685
+const TONNE_PER_LB = 1/2204.62  # [tonne/lb]
 
 include("keys.jl")
 include("core/types.jl")

--- a/src/REopt.jl
+++ b/src/REopt.jl
@@ -64,9 +64,6 @@ using ArchGDAL
 using Roots: fzero  # for IRR
 global hdl = nothing
 
-const M3_TO_GAL = 264.172  # [gal/m^3]
-const GAL_DIESEL_TO_KWH = 40.7  # [kWh/gal_diesel]
-
 include("keys.jl")
 include("core/types.jl")
 include("core/utils.jl")

--- a/src/constraints/chp_constraints.jl
+++ b/src/constraints/chp_constraints.jl
@@ -35,7 +35,7 @@ function add_chp_fuel_burn_constraints(m, p; _n="")
     fuel_burn_intercept = fuel_burn_full_load - fuel_burn_slope * 1.0  # [kWt/kWe_rated]
 
     # Fuel cost
-    fuel_cost_per_kwh = p.s.chp.fuel_cost_per_mmbtu / MMBTU_TO_KWH
+    fuel_cost_per_kwh = p.s.chp.fuel_cost_per_mmbtu / KWH_PER_MMBTU
     fuel_cost_series = per_hour_value_to_time_series(fuel_cost_per_kwh, p.s.settings.time_steps_per_hour, 
                                                      "CHP.fuel_cost_per_mmbtu")
     m[:TotalCHPFuelCosts] = @expression(m, p.pwf_fuel["CHP"] *

--- a/src/constraints/generator_constraints.jl
+++ b/src/constraints/generator_constraints.jl
@@ -29,13 +29,13 @@
 # *********************************************************************************
 function add_fuel_burn_constraints(m,p)
   	@constraint(m, [t in p.techs.gen, ts in p.time_steps],
-		m[:dvFuelUsage][t, ts] == p.s.generator.fuel_slope_gal_per_kwh *
-		p.production_factor[t, ts] * p.hours_per_timestep * m[:dvRatedProduction][t, ts] +
-		p.s.generator.fuel_intercept_gal_per_hr * p.hours_per_timestep * m[:binGenIsOnInTS][t, ts]
+		(m[:dvFuelUsage][t, ts] == p.s.generator.fuel_slope_gal_per_kwh * GAL_DIESEL_TO_KWH *
+		p.production_factor[t, ts] * p.hours_per_timestep * m[:dvRatedProduction][t, ts])
+		+ (p.s.generator.fuel_intercept_gal_per_hr * GAL_DIESEL_TO_KWH * p.hours_per_timestep * m[:binGenIsOnInTS][t, ts])
 	)
 	@constraint(m,
 		sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps) <=
-		p.s.generator.fuel_avail_gal
+		p.s.generator.fuel_avail_gal * GAL_DIESEL_TO_KWH
 	)
 end
 
@@ -89,6 +89,6 @@ function add_gen_constraints(m, p)
         m[:dvRatedProduction][t, ts] for t in p.techs.gen, ts in p.time_steps)
     )
     m[:TotalGenFuelCosts] = @expression(m, p.pwf_e *
-        sum(m[:dvFuelUsage][t,ts] * p.s.generator.fuel_cost_per_gallon for t in p.techs.gen, ts in p.time_steps)
+        sum(m[:dvFuelUsage][t,ts] * p.s.generator.fuel_cost_per_gallon / GAL_DIESEL_TO_KWH for t in p.techs.gen, ts in p.time_steps)
     )
 end

--- a/src/constraints/generator_constraints.jl
+++ b/src/constraints/generator_constraints.jl
@@ -29,7 +29,7 @@
 # *********************************************************************************
 function add_fuel_burn_constraints(m,p)
   	@constraint(m, [t in p.techs.gen, ts in p.time_steps],
-		(m[:dvFuelUsage][t, ts] == p.s.generator.fuel_slope_gal_per_kwh * GAL_DIESEL_TO_KWH *
+		m[:dvFuelUsage][t, ts] == (p.s.generator.fuel_slope_gal_per_kwh * GAL_DIESEL_TO_KWH *
 		p.production_factor[t, ts] * p.hours_per_timestep * m[:dvRatedProduction][t, ts]) +
 		(p.s.generator.fuel_intercept_gal_per_hr * GAL_DIESEL_TO_KWH * p.hours_per_timestep * m[:binGenIsOnInTS][t, ts])
 	)

--- a/src/constraints/generator_constraints.jl
+++ b/src/constraints/generator_constraints.jl
@@ -29,13 +29,13 @@
 # *********************************************************************************
 function add_fuel_burn_constraints(m,p)
   	@constraint(m, [t in p.techs.gen, ts in p.time_steps],
-		m[:dvFuelUsage][t, ts] == (p.s.generator.fuel_slope_gal_per_kwh * GAL_DIESEL_TO_KWH *
+		m[:dvFuelUsage][t, ts] == (p.s.generator.fuel_slope_gal_per_kwh * KWH_PER_GAL_DIESEL *
 		p.production_factor[t, ts] * p.hours_per_timestep * m[:dvRatedProduction][t, ts]) +
-		(p.s.generator.fuel_intercept_gal_per_hr * GAL_DIESEL_TO_KWH * p.hours_per_timestep * m[:binGenIsOnInTS][t, ts])
+		(p.s.generator.fuel_intercept_gal_per_hr * KWH_PER_GAL_DIESEL * p.hours_per_timestep * m[:binGenIsOnInTS][t, ts])
 	)
 	@constraint(m,
 		sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps) <=
-		p.s.generator.fuel_avail_gal * GAL_DIESEL_TO_KWH
+		p.s.generator.fuel_avail_gal * KWH_PER_GAL_DIESEL
 	)
 end
 
@@ -89,6 +89,6 @@ function add_gen_constraints(m, p)
         m[:dvRatedProduction][t, ts] for t in p.techs.gen, ts in p.time_steps)
     )
     m[:TotalGenFuelCosts] = @expression(m, p.pwf_e *
-        sum(m[:dvFuelUsage][t,ts] * p.s.generator.fuel_cost_per_gallon / GAL_DIESEL_TO_KWH for t in p.techs.gen, ts in p.time_steps)
+        sum(m[:dvFuelUsage][t,ts] * p.s.generator.fuel_cost_per_gallon / KWH_PER_GAL_DIESEL for t in p.techs.gen, ts in p.time_steps)
     )
 end

--- a/src/constraints/generator_constraints.jl
+++ b/src/constraints/generator_constraints.jl
@@ -30,8 +30,8 @@
 function add_fuel_burn_constraints(m,p)
   	@constraint(m, [t in p.techs.gen, ts in p.time_steps],
 		(m[:dvFuelUsage][t, ts] == p.s.generator.fuel_slope_gal_per_kwh * GAL_DIESEL_TO_KWH *
-		p.production_factor[t, ts] * p.hours_per_timestep * m[:dvRatedProduction][t, ts])
-		+ (p.s.generator.fuel_intercept_gal_per_hr * GAL_DIESEL_TO_KWH * p.hours_per_timestep * m[:binGenIsOnInTS][t, ts])
+		p.production_factor[t, ts] * p.hours_per_timestep * m[:dvRatedProduction][t, ts]) +
+		(p.s.generator.fuel_intercept_gal_per_hr * GAL_DIESEL_TO_KWH * p.hours_per_timestep * m[:binGenIsOnInTS][t, ts])
 	)
 	@constraint(m,
 		sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps) <=

--- a/src/core/absorption_chiller.jl
+++ b/src/core/absorption_chiller.jl
@@ -69,10 +69,10 @@ struct AbsorptionChiller <: AbstractThermalTech
         macrs_bonus_pct::Real = 0,
         )
 
-        min_kw = min_ton * TONHOUR_TO_KWH_THERMAL
-        max_kw = max_ton * TONHOUR_TO_KWH_THERMAL
-        installed_cost_per_kw = installed_cost_per_ton / TONHOUR_TO_KWH_THERMAL
-        om_cost_per_kw = om_cost_per_ton / TONHOUR_TO_KWH_THERMAL
+        min_kw = min_ton * KWH_THERMAL_PER_TONHOUR
+        max_kw = max_ton * KWH_THERMAL_PER_TONHOUR
+        installed_cost_per_kw = installed_cost_per_ton / KWH_THERMAL_PER_TONHOUR
+        om_cost_per_kw = om_cost_per_ton / KWH_THERMAL_PER_TONHOUR
 
         new(
             min_ton,

--- a/src/core/doe_commercial_reference_building_loads.jl
+++ b/src/core/doe_commercial_reference_building_loads.jl
@@ -147,7 +147,7 @@ function built_in_load(type::String, city::String, buildingtype::String,
         # CRB thermal "loads" are in terms of energy input required (boiler fuel), not the actual energy demand.
         # So we multiply the fuel energy by the boiler_efficiency to get the actual energy demand.
         boiler_efficiency = EXISTING_BOILER_EFFICIENCY
-        mmbtu_to_kwh = MMBTU_TO_KWH  # do convert thermal loads
+        mmbtu_to_kwh = KWH_PER_MMBTU  # do convert thermal loads
     end
     datetime = DateTime(year, 1, 1, 1)
     for ld in normalized_profile

--- a/src/core/doe_commercial_reference_building_loads.jl
+++ b/src/core/doe_commercial_reference_building_loads.jl
@@ -47,10 +47,6 @@ const default_buildings = [
     "FlatLoad",
 ]
 
-const MMBTU_TO_KWH = 293.07107
-const TONHOUR_TO_KWH_THERMAL = 3.51685
-const EXISTING_BOILER_EFFICIENCY = 0.8
-
 
 function find_ashrae_zone_city(lat, lon)::String
     file_path = joinpath(dirname(@__FILE__), "..", "..", "data", "climate_cities.shp")

--- a/src/core/existing_boiler.jl
+++ b/src/core/existing_boiler.jl
@@ -81,7 +81,7 @@ function ExistingBoiler(;
         "fuel_cell" => "hot_water"
     )
 
-    fuel_cost_per_kwh = fuel_cost_per_mmbtu / MMBTU_TO_KWH
+    fuel_cost_per_kwh = fuel_cost_per_mmbtu / KWH_PER_MMBTU
     fuel_cost_series = per_hour_value_to_time_series(fuel_cost_per_kwh, time_steps_per_hour, 
                                                      "ExistingBoiler.fuel_cost_per_mmbtu")
 

--- a/src/core/heating_cooling_loads.jl
+++ b/src/core/heating_cooling_loads.jl
@@ -72,7 +72,7 @@ struct DomesticHotWaterLoad
                 throw(@error "Provided domestic hot water load does not match the time_steps_per_hour.")
             end
 
-            loads_kw = fuel_loads_mmbtu_per_hour .* (MMBTU_TO_KWH * EXISTING_BOILER_EFFICIENCY)
+            loads_kw = fuel_loads_mmbtu_per_hour .* (KWH_PER_MMBTU * EXISTING_BOILER_EFFICIENCY)
 
         elseif !isempty(doe_reference_name)
             loads_kw = BuiltInDomesticHotWaterLoad(city, doe_reference_name, latitude, longitude, 2017, annual_mmbtu, monthly_mmbtu)
@@ -150,7 +150,7 @@ struct SpaceHeatingLoad
                 throw(@error "Provided space heating load does not match the time_steps_per_hour.")
             end
 
-            loads_kw = fuel_loads_mmbtu_per_hour .* (MMBTU_TO_KWH * EXISTING_BOILER_EFFICIENCY)
+            loads_kw = fuel_loads_mmbtu_per_hour .* (KWH_PER_MMBTU * EXISTING_BOILER_EFFICIENCY)
 
         elseif !isempty(doe_reference_name)
             loads_kw = BuiltInSpaceHeatingLoad(city, doe_reference_name, latitude, longitude, 2017, annual_mmbtu, monthly_mmbtu)
@@ -193,9 +193,9 @@ function get_existing_chiller_default_cop(; existing_chiller_max_thermal_factor_
     cop_unknown_thermal = (cop_less_than_100_ton + cop_more_than_100_ton) / 2.0
     max_cooling_load_ton = nothing
     if !isnothing(loads_kw_thermal)
-        max_cooling_load_ton = maximum(loads_kw_thermal) / TONHOUR_TO_KWH_THERMAL
+        max_cooling_load_ton = maximum(loads_kw_thermal) / KWH_THERMAL_PER_TONHOUR
     elseif !isnothing(loads_kw)
-        max_cooling_load_ton = maximum(loads_kw) / TONHOUR_TO_KWH_THERMAL * cop_unknown_thermal
+        max_cooling_load_ton = maximum(loads_kw) / KWH_THERMAL_PER_TONHOUR * cop_unknown_thermal
     end
     if isnothing(max_cooling_load_ton) || isnothing(existing_chiller_max_thermal_factor_on_peak_load)
         return cop_unknown_thermal
@@ -274,7 +274,7 @@ struct CoolingLoad
             if !(length(thermal_loads_ton) / time_steps_per_hour ≈ 8760)
                 throw(@error "Provided cooling load does not match the time_steps_per_hour.")
             end
-            loads_kw_thermal = thermal_loads_ton .* TONHOUR_TO_KWH_THERMAL
+            loads_kw_thermal = thermal_loads_ton .* KWH_THERMAL_PER_TONHOUR
         
         elseif !isempty(per_time_step_fractions_of_electric_load) && (length(site_electric_load_profile) / time_steps_per_hour ≈ 8760)
             if !(length(per_time_step_fractions_of_electric_load) / time_steps_per_hour ≈ 8760)
@@ -1358,11 +1358,11 @@ function BuiltInCoolingLoad(
     if isnothing(annual_tonhour)
         annual_kwh = cooling_annual_kwh[city][buildingtype]
     else
-        annual_kwh = annual_tonhour * TONHOUR_TO_KWH_THERMAL / existing_chiller_cop
+        annual_kwh = annual_tonhour * KWH_THERMAL_PER_TONHOUR / existing_chiller_cop
     end
     monthly_kwh = Real[]
     if length(monthly_tonhour) == 12
-        monthly_kwh = monthly_tonhour * TONHOUR_TO_KWH_THERMAL / existing_chiller_cop
+        monthly_kwh = monthly_tonhour * KWH_THERMAL_PER_TONHOUR / existing_chiller_cop
     end
     built_in_load("cooling", city, buildingtype, year, annual_kwh, monthly_kwh)
 end

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -447,7 +447,7 @@ function add_variables!(m::JuMP.AbstractModel, p::REoptInputs)
 	end
 
     if !isempty(p.techs.fuel_burning)
-		@variable(m, dvFuelUsage[p.techs.fuel_burning, p.time_steps] >= 0) # Fuel burned by technology t in each time step
+		@variable(m, dvFuelUsage[p.techs.fuel_burning, p.time_steps] >= 0) # Fuel burned by technology t in each time step [kWh]
     end
 
     if !isempty(p.s.electric_tariff.export_bins)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -28,13 +28,6 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 # *********************************************************************************
 
-const M3_TO_GAL = 264.172  # [gal/m^3]
-const GAL_DIESEL_TO_KWH = 40.7  # [kWh/gal_diesel]
-const MMBTU_TO_KWH = 293.07107  # [kWh/mmbtu]
-const TONHOUR_TO_KWH_THERMAL = 3.51685
-const EXISTING_BOILER_EFFICIENCY = 0.8
-const TONNES_TO_LBS = 2204.62  # [lb/tonne]
-
 function annuity(years::Int, rate_escalation::Float64, rate_discount::Float64)
     """
         this formulation assumes cost growth in first period

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -28,6 +28,13 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 # *********************************************************************************
 
+const M3_TO_GAL = 264.172  # [gal/m^3]
+const GAL_DIESEL_TO_KWH = 40.7  # [kWh/gal_diesel]
+const MMBTU_TO_KWH = 293.07107  # [kWh/mmbtu]
+const TONHOUR_TO_KWH_THERMAL = 3.51685
+const EXISTING_BOILER_EFFICIENCY = 0.8
+const TONNES_TO_LBS = 2204.62  # [lb/tonne]
+
 function annuity(years::Int, rate_escalation::Float64, rate_discount::Float64)
     """
         this formulation assumes cost growth in first period

--- a/src/mpc/model.jl
+++ b/src/mpc/model.jl
@@ -288,7 +288,7 @@ function add_variables!(m::JuMP.AbstractModel, p::MPCInputs)
 		@warn """Adding binary variable to model gas generator. 
 				 Some solvers are very slow with integer variables"""
 		@variables m begin
-			dvFuelUsage[p.techs.gen, p.time_steps] >= 0 # Fuel burned by technology t in each time step
+			dvFuelUsage[p.techs.gen, p.time_steps] >= 0 # Fuel burned by technology t in each time step [kWh]
 			binGenIsOnInTS[p.techs.gen, p.time_steps], Bin  # 1 If technology t is operating in time step h; 0 otherwise
 		end
 	end

--- a/src/results/absorption_chiller.jl
+++ b/src/results/absorption_chiller.jl
@@ -36,16 +36,16 @@ function add_absorption_chiller_results(m::JuMP.AbstractModel, p::REoptInputs, d
 	# r["existing_chiller_to_tes_series"] = round.(value.(ELECCHLtoTES), digits=3)
 
 	r["size_kw"] = value(sum(m[:dvSize][t] for t in p.techs.absorption_chiller))
-	r["size_ton"] = r["size_kw"] / TONHOUR_TO_KWH_THERMAL
+	r["size_ton"] = r["size_kw"] / KWH_THERMAL_PER_TONHOUR
 	@expression(m, ABSORPCHLtoTES[ts in p.time_steps],
 		sum(m[:dvProductionToStorage][b,t,ts] for b in p.s.storage.types.cold, t in p.techs.absorption_chiller))
-	r["year_one_to_tes_series_ton"] = round.(value.(ABSORPCHLtoTES / TONHOUR_TO_KWH_THERMAL), digits=3)
+	r["year_one_to_tes_series_ton"] = round.(value.(ABSORPCHLtoTES / KWH_THERMAL_PER_TONHOUR), digits=3)
 	@expression(m, ABSORPCHLtoLoad[ts in p.time_steps],
 		sum(m[:dvThermalProduction][t,ts] for t in p.techs.absorption_chiller)
 			- ABSORPCHLtoTES[ts]) 
-	r["year_one_to_load_series_ton"] = round.(value.(ABSORPCHLtoLoad / TONHOUR_TO_KWH_THERMAL), digits=3)
+	r["year_one_to_load_series_ton"] = round.(value.(ABSORPCHLtoLoad / KWH_THERMAL_PER_TONHOUR), digits=3)
 	@expression(m, ABSORPCHLThermalConsumptionSeries[ts in p.time_steps],
-		sum(m[:dvThermalProduction][t,ts] / p.thermal_cop[t] for t in p.techs.absorption_chiller) / TONHOUR_TO_KWH_THERMAL)
+		sum(m[:dvThermalProduction][t,ts] / p.thermal_cop[t] for t in p.techs.absorption_chiller) / KWH_THERMAL_PER_TONHOUR)
 	r["year_one_thermal_consumption_series"] = round.(value.(ABSORPCHLThermalConsumptionSeries), digits=3)
 	@expression(m, Year1ABSORPCHLThermalConsumption,
 		p.hours_per_timestep * sum(m[:dvThermalProduction][t,ts] / p.thermal_cop[t]
@@ -54,7 +54,7 @@ function add_absorption_chiller_results(m::JuMP.AbstractModel, p::REoptInputs, d
 	@expression(m, Year1ABSORPCHLThermalProd,
 		p.hours_per_timestep * sum(m[:dvThermalProduction][t, ts]
 			for t in p.techs.absorption_chiller, ts in p.time_steps))
-	r["year_one_thermal_production_tonhour"] = round(value(Year1ABSORPCHLThermalProd / TONHOUR_TO_KWH_THERMAL), digits=3)
+	r["year_one_thermal_production_tonhour"] = round(value(Year1ABSORPCHLThermalProd / KWH_THERMAL_PER_TONHOUR), digits=3)
     @expression(m, ABSORPCHLElectricConsumptionSeries[ts in p.time_steps],
         sum(m[:dvThermalProduction][t,ts] / p.cop[t] for t in p.techs.absorption_chiller) )
     r["year_one_electric_consumption_series"] = round.(value.(ABSORPCHLElectricConsumptionSeries), digits=3)

--- a/src/results/chp.jl
+++ b/src/results/chp.jl
@@ -53,7 +53,7 @@ function add_chp_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
 	r["size_kw"] = value(sum(m[Symbol("dvSize"*_n)][t] for t in p.techs.chp))
     r["size_supplemental_firing_kw"] = value(sum(m[Symbol("dvSupplementaryFiringSize"*_n)][t] for t in p.techs.chp))
 	@expression(m, CHPFuelUsedKWH, sum(m[Symbol("dvFuelUsage"*_n)][t, ts] for t in p.techs.chp, ts in p.time_steps))
-	r["year_one_fuel_used_mmbtu"] = round(value(CHPFuelUsedKWH) / MMBTU_TO_KWH, digits=3)
+	r["year_one_fuel_used_mmbtu"] = round(value(CHPFuelUsedKWH) / KWH_PER_MMBTU, digits=3)
 	@expression(m, Year1CHPElecProd,
 		p.hours_per_timestep * sum(m[Symbol("dvRatedProduction"*_n)][t,ts] * p.production_factor[t, ts]
 			for t in p.techs.chp, ts in p.time_steps))
@@ -63,7 +63,7 @@ function add_chp_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
         m[Symbol("dvSupplementaryThermalProduction"*_n)][t,ts] - 
         m[Symbol("dvProductionToWaste"*_n)][t,ts] 
             for t in p.techs.chp, ts in p.time_steps))
-	r["year_one_thermal_energy_produced_mmbtu"] = round(value(Year1CHPThermalProdKWH) / MMBTU_TO_KWH, digits=3)
+	r["year_one_thermal_energy_produced_mmbtu"] = round(value(Year1CHPThermalProdKWH) / KWH_PER_MMBTU, digits=3)
 	@expression(m, CHPElecProdTotal[ts in p.time_steps],
 		sum(m[Symbol("dvRatedProduction"*_n)][t,ts] * p.production_factor[t, ts] for t in p.techs.chp))
 	r["year_one_electric_production_series_kw"] = round.(value.(CHPElecProdTotal), digits=3)
@@ -88,7 +88,7 @@ function add_chp_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
 	else 
 		CHPtoHotTES = zeros(length(p.time_steps))
 	end
-	r["year_one_thermal_to_tes_series_mmbtu_per_hour"] = round.(value.(CHPtoHotTES / MMBTU_TO_KWH), digits=5)
+	r["year_one_thermal_to_tes_series_mmbtu_per_hour"] = round.(value.(CHPtoHotTES / KWH_PER_MMBTU), digits=5)
     # if !isempty(p.SteamTurbineTechs)
     #     @expression(m, CHPToSteamTurbine[ts in p.time_steps], sum(m[Symbol("dvThermalToSteamTurbine"*_n)][t,ts] for t in p.techs.chp))
     #     r["year_one_thermal_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(CHPToSteamTurbine), digits=3)
@@ -98,14 +98,14 @@ function add_chp_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
     # end
 	@expression(m, CHPThermalToWasteKW[ts in p.time_steps],
 		sum(m[Symbol("dvProductionToWaste"*_n)][t,ts] for t in p.techs.chp))
-	r["year_one_thermal_to_waste_series_mmbtu_per_hour"] = round.(value.(CHPThermalToWasteKW) / MMBTU_TO_KWH, digits=5)
+	r["year_one_thermal_to_waste_series_mmbtu_per_hour"] = round.(value.(CHPThermalToWasteKW) / KWH_PER_MMBTU, digits=5)
 	# @expression(m, CHPThermalToLoad[ts in p.time_steps],
 	# 	sum(m[Symbol("dvThermalProduction"*_n)][t,ts] + m[Symbol("dvSupplementaryThermalProduction"*_n)][t,ts]
 	# 		for t in p.techs.chp) - CHPtoHotTES[ts] - CHPToSteamTurbine[ts] - CHPThermalToWaste[ts])
     @expression(m, CHPThermalToLoadKW[ts in p.time_steps],
         sum(m[Symbol("dvThermalProduction"*_n)][t,ts] for t in p.techs.chp) - 
         CHPtoHotTES[ts] - CHPThermalToWasteKW[ts])
-	r["year_one_thermal_to_load_series_mmbtu_per_hour"] = round.(value.(CHPThermalToLoadKW) / MMBTU_TO_KWH, digits=5)
+	r["year_one_thermal_to_load_series_mmbtu_per_hour"] = round.(value.(CHPThermalToLoadKW) / KWH_PER_MMBTU, digits=5)
     r["year_one_chp_fuel_cost"] = round(value(m[:TotalCHPFuelCosts] / p.pwf_fuel["CHP"]), digits=3)                
 	r["lifecycle_chp_fuel_cost"] = round(value(m[:TotalCHPFuelCosts]) * p.s.financial.offtaker_tax_pct, digits=3)
 	#Standby charges and hourly O&M

--- a/src/results/existing_boiler.jl
+++ b/src/results/existing_boiler.jl
@@ -31,13 +31,13 @@ function add_existing_boiler_results(m::JuMP.AbstractModel, p::REoptInputs, d::D
     r = Dict{String, Any}()
 
     # TODO all of these time series assume hourly time steps
-    # TODO we convert MMBTU_TO_KWH from user inputs to the model, and then back to mmbtu in outputs: why not stay in mmbtu?
+    # TODO we convert KWH_PER_MMBTU from user inputs to the model, and then back to mmbtu in outputs: why not stay in mmbtu?
 	r["year_one_fuel_consumption_mmbtu_per_hour"] = 
-        round.(value.(m[:dvFuelUsage]["ExistingBoiler", ts] for ts in p.time_steps) / MMBTU_TO_KWH, digits=3)
+        round.(value.(m[:dvFuelUsage]["ExistingBoiler", ts] for ts in p.time_steps) / KWH_PER_MMBTU, digits=3)
     r["year_one_fuel_consumption_mmbtu"] = round(sum(r["year_one_fuel_consumption_mmbtu_per_hour"]), digits=3)
 
 	r["year_one_thermal_production_mmbtu_per_hour"] = 
-        round.(value.(m[:dvThermalProduction]["ExistingBoiler", ts] for ts in p.time_steps) / MMBTU_TO_KWH, digits=3)
+        round.(value.(m[:dvThermalProduction]["ExistingBoiler", ts] for ts in p.time_steps) / KWH_PER_MMBTU, digits=3)
 	r["year_one_thermal_production_mmbtu"] = round(sum(r["year_one_thermal_production_mmbtu_per_hour"]), digits=3)
 
 	if !isempty(p.s.storage.types.hot)
@@ -47,7 +47,7 @@ function add_existing_boiler_results(m::JuMP.AbstractModel, p::REoptInputs, d::D
     else
         BoilerToHotTESKW = zeros(length(p.time_steps))
     end
-	r["thermal_to_tes_series_mmbtu_per_hour"] = round.(value.(BoilerToHotTESKW / MMBTU_TO_KWH), digits=3)
+	r["thermal_to_tes_series_mmbtu_per_hour"] = round.(value.(BoilerToHotTESKW / KWH_PER_MMBTU), digits=3)
 
     # if !isempty(p.SteamTurbineTechs)
     #     @expression(m, BoilerToSteamTurbine[ts in p.time_steps], m[:dvThermalToSteamTurbine]["ExistingBoiler",ts])
@@ -60,7 +60,7 @@ function add_existing_boiler_results(m::JuMP.AbstractModel, p::REoptInputs, d::D
 	@expression(m, BoilerToLoad[ts in p.time_steps],
 		m[:dvThermalProduction]["ExistingBoiler",ts] - BoilerToHotTESKW[ts] #- BoilerToSteamTurbine[ts]
     )
-	r["year_one_thermal_to_load_series_mmbtu_per_hour"] = round.(value.(BoilerToLoad / MMBTU_TO_KWH), digits=3)
+	r["year_one_thermal_to_load_series_mmbtu_per_hour"] = round.(value.(BoilerToLoad / KWH_PER_MMBTU), digits=3)
 
 	r["lifecycle_fuel_cost"] = round(value(m[:TotalExistingBoilerFuelCosts]) * (1 - p.s.financial.offtaker_tax_pct), digits=3)
 	r["year_one_fuel_cost"] = round(value(m[:TotalExistingBoilerFuelCosts]) / p.pwf_fuel["ExistingBoiler"], digits=3)

--- a/src/results/existing_chiller.jl
+++ b/src/results/existing_chiller.jl
@@ -33,13 +33,13 @@ function add_existing_chiller_results(m::JuMP.AbstractModel, p::REoptInputs, d::
 	@expression(m, ELECCHLtoTES[ts in p.time_steps],
 		sum(m[:dvProductionToStorage][b,"ExistingChiller",ts] for b in p.s.storage.types.cold, t in p.techs.cooling)
     )
-	r["year_one_to_tes_series_ton"] = round.(value.(ELECCHLtoTES / TONHOUR_TO_KWH_THERMAL), digits=3)   
+	r["year_one_to_tes_series_ton"] = round.(value.(ELECCHLtoTES / KWH_THERMAL_PER_TONHOUR), digits=3)   
 
 	@expression(m, ELECCHLtoLoad[ts in p.time_steps],
 		sum(m[:dvThermalProduction]["ExistingChiller", ts])
 			- ELECCHLtoTES[ts]
     )
-	r["year_one_to_load_series_ton"] = round.(value.(ELECCHLtoLoad / TONHOUR_TO_KWH_THERMAL).data, digits=3)
+	r["year_one_to_load_series_ton"] = round.(value.(ELECCHLtoLoad / KWH_THERMAL_PER_TONHOUR).data, digits=3)
 
 	@expression(m, ELECCHLElecConsumptionSeries[ts in p.time_steps],
 		sum(m[:dvThermalProduction]["ExistingChiller", ts] / p.cop["ExistingChiller"])
@@ -56,7 +56,7 @@ function add_existing_chiller_results(m::JuMP.AbstractModel, p::REoptInputs, d::
 		p.hours_per_timestep * sum(m[:dvThermalProduction]["ExistingChiller", ts]
 			for ts in p.time_steps)
     )
-	r["year_one_thermal_production_tonhour"] = round(value(Year1ELECCHLThermalProd / TONHOUR_TO_KWH_THERMAL), digits=3)
+	r["year_one_thermal_production_tonhour"] = round(value(Year1ELECCHLThermalProd / KWH_THERMAL_PER_TONHOUR), digits=3)
 
     d["ExistingChiller"] = r
 	nothing

--- a/src/results/generator.jl
+++ b/src/results/generator.jl
@@ -85,7 +85,7 @@ function add_generator_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _
 	)
 	r["year_one_to_load_series_kw"] = round.(value.(generatorToLoad), digits=3)
 
-    GeneratorFuelUsed = @expression(m, sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps))
+    GeneratorFuelUsed = @expression(m, sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps) / GAL_DIESEL_TO_KWH)
 	r["fuel_used_gal"] = round(value(GeneratorFuelUsed), digits=2)
 
 	Year1GenProd = @expression(m,
@@ -131,7 +131,7 @@ function add_generator_results(m::JuMP.AbstractModel, p::MPCInputs, d::Dict; _n=
 	)
 	r["to_load_series_kw"] = round.(value.(generatorToLoad), digits=3).data
 
-    GeneratorFuelUsed = @expression(m, sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps))
+    GeneratorFuelUsed = @expression(m, sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps) / GAL_DIESEL_TO_KWH)
 	r["fuel_used_gal"] = round(value(GeneratorFuelUsed), digits=2)
 
 	Year1GenProd = @expression(m,

--- a/src/results/generator.jl
+++ b/src/results/generator.jl
@@ -85,7 +85,7 @@ function add_generator_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _
 	)
 	r["year_one_to_load_series_kw"] = round.(value.(generatorToLoad), digits=3)
 
-    GeneratorFuelUsed = @expression(m, sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps) / GAL_DIESEL_TO_KWH)
+    GeneratorFuelUsed = @expression(m, sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps) / KWH_PER_GAL_DIESEL)
 	r["fuel_used_gal"] = round(value(GeneratorFuelUsed), digits=2)
 
 	Year1GenProd = @expression(m,
@@ -131,7 +131,7 @@ function add_generator_results(m::JuMP.AbstractModel, p::MPCInputs, d::Dict; _n=
 	)
 	r["to_load_series_kw"] = round.(value.(generatorToLoad), digits=3).data
 
-    GeneratorFuelUsed = @expression(m, sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps) / GAL_DIESEL_TO_KWH)
+    GeneratorFuelUsed = @expression(m, sum(m[:dvFuelUsage][t, ts] for t in p.techs.gen, ts in p.time_steps) / KWH_PER_GAL_DIESEL)
 	r["fuel_used_gal"] = round(value(GeneratorFuelUsed), digits=2)
 
 	Year1GenProd = @expression(m,

--- a/src/results/thermal_storage.jl
+++ b/src/results/thermal_storage.jl
@@ -53,7 +53,7 @@ function add_hot_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict,
         r["year_one_soc_series_pct"] = round.(value.(soc) ./ size_kwh, digits=3)
 
         discharge = (m[Symbol("dvDischargeFromStorage"*_n)][b, ts] for ts in p.time_steps)
-        r["year_one_to_load_series_mmbtu_per_hour"] = round.(value.(discharge) / MMBTU_TO_KWH, digits=7)
+        r["year_one_to_load_series_mmbtu_per_hour"] = round.(value.(discharge) / KWH_PER_MMBTU, digits=7)
     else
         r["year_one_soc_series_pct"] = []
         r["year_one_to_load_series_mmbtu_per_hour"] = []
@@ -89,7 +89,7 @@ function add_cold_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict
         r["year_one_soc_series_pct"] = round.(value.(soc) ./ size_kwh, digits=3)
 
         discharge = (m[Symbol("dvDischargeFromStorage"*_n)][b, ts] for ts in p.time_steps)
-        r["year_one_to_load_series_ton"] = round.(value.(discharge) / TONHOUR_TO_KWH_THERMAL, digits=7)
+        r["year_one_to_load_series_ton"] = round.(value.(discharge) / KWH_THERMAL_PER_TONHOUR, digits=7)
     else
         r["year_one_soc_series_pct"] = []
         r["year_one_to_load_series_ton"] = []

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -675,7 +675,7 @@ end
 
     # Annual cooling **thermal** energy load of CRB is based on annual cooling electric energy (from CRB models) and a conditional COP depending on the peak cooling thermal load
     # When the user specifies inputs["ExistingChiller"]["cop"], this changes the **electric** consumption of the chiller to meet that cooling thermal load
-    cooling_thermal_load_ton_hr_total = 1427329.0 * inputs.s.cooling_load.existing_chiller_cop / REopt.TONHOUR_TO_KWH_THERMAL  # From CRB models, in heating_cooling_loads.jl, BuiltInCoolingLoad data for location (SanFrancisco Hospital)
+    cooling_thermal_load_ton_hr_total = 1427329.0 * inputs.s.cooling_load.existing_chiller_cop / REopt.KWH_THERMAL_PER_TONHOUR  # From CRB models, in heating_cooling_loads.jl, BuiltInCoolingLoad data for location (SanFrancisco Hospital)
     cooling_electric_load_total_mod_cop = cooling_thermal_load_ton_hr_total / inputs.s.existing_chiller.cop
 
     # Annual heating **thermal** energy load of CRB is based on annual boiler fuel energy (from CRB models) and assumed const EXISTING_BOILER_EFFICIENCY
@@ -706,7 +706,7 @@ end
     @test tes_effic_with_decay < 0.97
     println("tes_effic_with_decay = ", tes_effic_with_decay)
     @test round(cooling_total_prod_from_techs, digits=0) ≈ cooling_load_plus_tes_losses atol=5.0
-    #self.assertAlmostEqual(absorpchl_total_cooling_produced_ton_hour * REopt.TONHOUR_TO_KWH_THERMAL / absorpchl_cop_elec, absorpchl_electric_consumption_total_kwh, places=1)
+    #self.assertAlmostEqual(absorpchl_total_cooling_produced_ton_hour * REopt.KWH_THERMAL_PER_TONHOUR / absorpchl_cop_elec, absorpchl_electric_consumption_total_kwh, places=1)
 
     # Heating outputs
     boiler_fuel_consumption_calculated = results["ExistingBoiler"]["year_one_fuel_consumption_mmbtu"]
@@ -730,7 +730,7 @@ end
 
     # Test CHP.cooling_thermal_factor = 0.8, AbsorptionChiller.chiller_cop = 0.7 (from test_cold_POST.json)
     # absorpchl_heat_in_kwh = results["AbsorptionChiller"]["year_one_absorp_chl_thermal_consumption_mmbtu"] * 1.0E6 / 3412.0
-    # absorpchl_cool_out_kwh = results["AbsorptionChiller"]["year_one_absorp_chl_thermal_production_tonhr"] * REopt.TONHOUR_TO_KWH_THERMAL
+    # absorpchl_cool_out_kwh = results["AbsorptionChiller"]["year_one_absorp_chl_thermal_production_tonhr"] * REopt.KWH_THERMAL_PER_TONHOUR
     #absorpchl_cop = absorpchl_cool_out_kwh / absorpchl_heat_in_kwh
 
     #self.assertAlmostEqual(absorpchl_cop, 0.8*0.7, places=3)
@@ -752,7 +752,7 @@ end
     # Heating load data from CRB models is **fuel**; we convert fuel to thermal using a constant/fixed REopt.EXISTING_BOILER_EFFICIENCY,
     #   so the thermal load is always the same for a standard CRB
     # The **fuel** consumption to serve that thermal load may change if the user inputs a different ExistingBoiler["efficiency"]
-    total_boiler_heating_thermal_load_mmbtu = (sum(inputs.s.space_heating_load.loads_kw) + sum(inputs.s.dhw_load.loads_kw)) / REopt.MMBTU_TO_KWH
+    total_boiler_heating_thermal_load_mmbtu = (sum(inputs.s.space_heating_load.loads_kw) + sum(inputs.s.dhw_load.loads_kw)) / REopt.KWH_PER_MMBTU
     @test round(total_boiler_heating_thermal_load_mmbtu, digits=0) ≈ 2904 * REopt.EXISTING_BOILER_EFFICIENCY atol=1.0  # The input load is **fuel**, not thermal
     total_boiler_heating_fuel_load_mmbtu = total_boiler_heating_thermal_load_mmbtu / inputs.s.existing_boiler.efficiency
     @test round(total_boiler_heating_fuel_load_mmbtu, digits=0) ≈ 2904 * REopt.EXISTING_BOILER_EFFICIENCY / inputs.s.existing_boiler.efficiency atol=1.0
@@ -782,7 +782,7 @@ end
     inputs = REoptInputs(s)
 
     total_heating_fuel_load_mmbtu = (sum(inputs.s.space_heating_load.loads_kw) + 
-                                    sum(inputs.s.dhw_load.loads_kw)) / REopt.EXISTING_BOILER_EFFICIENCY / REopt.MMBTU_TO_KWH
+                                    sum(inputs.s.dhw_load.loads_kw)) / REopt.EXISTING_BOILER_EFFICIENCY / REopt.KWH_PER_MMBTU
     @test round(total_heating_fuel_load_mmbtu, digits=0) ≈ 12000 atol=1.0
     total_chiller_electric_consumption = sum(inputs.s.cooling_load.loads_kw_thermal) / inputs.s.cooling_load.existing_chiller_cop
     @test round(total_chiller_electric_consumption, digits=0) ≈ 775282 atol=1.0
@@ -795,7 +795,7 @@ end
     inputs = REoptInputs(s)
 
     total_heating_fuel_load_mmbtu = (sum(inputs.s.space_heating_load.loads_kw) + 
-                                    sum(inputs.s.dhw_load.loads_kw)) / REopt.EXISTING_BOILER_EFFICIENCY / REopt.MMBTU_TO_KWH
+                                    sum(inputs.s.dhw_load.loads_kw)) / REopt.EXISTING_BOILER_EFFICIENCY / REopt.KWH_PER_MMBTU
     @test round(total_heating_fuel_load_mmbtu, digits=0) ≈ 8760 atol=0.1
     @test round(sum(inputs.s.cooling_load.loads_kw_thermal) / inputs.s.cooling_load.existing_chiller_cop, digits=0) ≈ 77528.0 atol=1.0
 
@@ -810,7 +810,7 @@ end
     s = Scenario(input_data)
     inputs = REoptInputs(s)
     
-    @test round(sum(inputs.s.cooling_load.loads_kw_thermal) / REopt.TONHOUR_TO_KWH_THERMAL, digits=0) ≈ annual_tonhour atol=1.0 
+    @test round(sum(inputs.s.cooling_load.loads_kw_thermal) / REopt.KWH_THERMAL_PER_TONHOUR, digits=0) ≈ annual_tonhour atol=1.0 
 end
 
 @testset "Hybrid/blended heating and cooling loads" begin


### PR DESCRIPTION
Decision variable dvFuelUsage is supposed to be in units of kWh, but for Generator techs it is in units of gallons. This PR changes the units of dvFuelUsage for Generator techs to kWh to be consistent with all other fuel burning techs and to avoid calculation errors this inconsistency would likely cause in the future.