### PR TITLE
Use nsrdb for PV only where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # REopt Changelog
 
 ## Develop
+In `prodfactor.jl`, include lat-long coordinates if-statement to determine whether the "nsrdb" dataset should be used in call to PVWatts. Accounts for recent updates to NSRDB data used by PVWatts (v6). If outside of NSRDB range, use "intl" (international) dataset. 
+## Develop
 - Update PV defaults to tilt=10 for rooftop, tilt = abs(lat) for ground mount, azimuth = 180 for northern lats, azimuth = 0 for southern lats.
 -  bug fix for Generator inputs to allow for time_steps_per_hour > 1
 ## v0.16.1

--- a/src/core/prodfactor.jl
+++ b/src/core/prodfactor.jl
@@ -35,11 +35,21 @@ function prodfactor(pv::PV, latitude::Real, longitude::Real; timeframe="hourly",
         return pv.prod_factor_series
     end
 
+    # Check if site is beyond the bounds of the NRSDB dataset. If so, use the international dataset.
+    dataset = "nsrdb"
+    if longitude < -179.5 || longitude > -21.0 || latitude < -21.5 || latitude > 60.0
+        if longitude < 81.5 || longitude > 179.5 || latitude < -43.8 || latitude > 60.0 
+            if longitude < 67.0 || longitude > 81.5 || latitude < -43.8 || latitude > 38.0
+                dataset = "intl"
+            end
+        end
+    end
+
     url = string("https://developer.nrel.gov/api/pvwatts/v6.json", "?api_key=", nrel_developer_key,
         "&lat=", latitude , "&lon=", longitude, "&tilt=", pv.tilt,
         "&system_capacity=1", "&azimuth=", pv.azimuth, "&module_type=", pv.module_type,
         "&array_type=", pv.array_type, "&losses=", round(pv.losses*100, digits=3), "&dc_ac_ratio=", pv.dc_ac_ratio,
-        "&gcr=", pv.gcr, "&inv_eff=", pv.inv_eff*100, "&timeframe=", timeframe, "&dataset=nsrdb",
+        "&gcr=", pv.gcr, "&inv_eff=", pv.inv_eff*100, "&timeframe=", timeframe, "&dataset=", dataset,
         "&radius=", pv.radius
     )
 

--- a/src/core/pv.jl
+++ b/src/core/pv.jl
@@ -134,7 +134,7 @@ struct PV <: AbstractTech
         losses::Real=0.14,
         azimuth::Real = latitude≥0 ? 180 : 0, # set azimuth to zero for southern hemisphere
         gcr::Real=0.4,
-        radius::Int=0,
+        radius::Int=0, # Radius, in miles, to use when searching for the closest climate data station. Use zero to use the closest station regardless of the distance
         name::String="PV",
         location::String="both",
         existing_kw::Real=0,


### PR DESCRIPTION
### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
- Bug fix: In `prodfactor.jl`, include lat-long coordinates if-statement to determine whether the "nsrdb" dataset should be used in call to PVWatts. Accounts for recent updates to NSRDB data used by PVWatts (v6). If outside of NSRDB range, use "intl" (international) dataset. 

### What is the current behavior?
(You can also link to an open issue here)
- Currently always applies "NSRDB" data for any site location. However, this will result in very inaccurate data being applied for sites outside of NSRDB bounds. 

### Other information:
These are the bounds that are now applied to the NSRDB query: 
![image](https://user-images.githubusercontent.com/16725585/172730138-6dc9e789-02d1-4353-9606-dee903b94440.png)
