### PR TITLE
Avoid triggering duplicate GitHub workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,9 @@
 name: Run tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   highstests:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,7 @@ name: Run tests
 
 on:
   push:
+    paths-ignore: [README.md, CHANGELOG.md]
   pull_request:
     types: [opened, reopened, ready_for_review]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # REopt Changelog
+## Develop
+### Changed
+- Avoid triggering duplicate GitHub workflows. When pushing to a branch that's in a PR, only trigger tests on the push not on the PR sync also.
 
 ## v0.17.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # REopt Changelog
 ## Develop
 ### Changed
+- Don't trigger GitHub 'Run test' workflow on a push that only changes README.md and/or CHANGELOG.md
 - Avoid triggering duplicate GitHub workflows. When pushing to a branch that's in a PR, only trigger tests on the push not on the PR sync also.
 
 ## v0.17.0


### PR DESCRIPTION
When pushing to a branch that's in a PR, only trigger tests on the push not on the PR sync also.