### PR TITLE
Schedule-based Flat loads, Addressable Load for Heating, and Cooling Load Error

### DIFF
--- a/src/constraints/thermal_tech_constraints.jl
+++ b/src/constraints/thermal_tech_constraints.jl
@@ -65,7 +65,13 @@ end
 
 function add_cooling_tech_constraints(m, p; _n="")
     # Constraint (7_cooling_prod_size): Production limit based on size for boiler
-    @constraint(m, [t in p.techs.cooling, ts in p.time_steps],
+    @constraint(m, [t in p.techs.cooling, ts in p.time_steps_with_grid],
         m[Symbol("dvThermalProduction"*_n)][t,ts] <= m[Symbol("dvSize"*_n)][t]
     )
+    # The load balance for cooling is only applied to time_steps_with_grid, so make sure we don't arbitrarily show cooling production for time_steps_without_grid
+    for t in p.techs.cooling
+        for ts in p.time_steps_without_grid
+            fix(m[Symbol("dvThermalProduction"*_n)][t, ts], 0.0, force=true)
+        end
+    end
 end

--- a/src/core/electric_load.jl
+++ b/src/core/electric_load.jl
@@ -86,6 +86,11 @@
     - Supermarket
     - Warehouse
     - FlatLoad
+    - FlatLoad_24_5
+    - FlatLoad_16_7
+    - FlatLoad_16_5
+    - FlatLoad_8_7
+    - FlatLoad_8_5   
 
     Each `city` and `doe_reference_name` combination has a default `annual_kwh`, or you can provide your
     own `annual_kwh` or `monthly_totals_kwh` and the reference profile will be scaled appropriately.
@@ -503,7 +508,12 @@ function BuiltInElectricLoad(
     end
 
     if isnothing(annual_kwh)
-        annual_kwh = annual_loads[city][lowercase(buildingtype)]
+        # Use FlatLoad annual_kwh from data for all types of FlatLoads because we don't have separate data for e.g. FlatLoad_16_7
+        if occursin("FlatLoad", buildingtype)
+            annual_kwh = annual_loads[city][lowercase("FlatLoad")]
+        else
+            annual_kwh = annual_loads[city][lowercase(buildingtype)]
+        end
     end
 
     built_in_load("electric", city, buildingtype, year, annual_kwh, monthly_totals_kwh)

--- a/src/core/heating_cooling_loads.jl
+++ b/src/core/heating_cooling_loads.jl
@@ -702,7 +702,12 @@ function BuiltInDomesticHotWaterLoad(
         error("buildingtype $(buildingtype) not in $(default_buildings).")
     end
     if isnothing(annual_mmbtu)
-        annual_mmbtu = dhw_annual_mmbtu[city][buildingtype]
+        # Use FlatLoad annual_mmbtu from data for all types of FlatLoads because we don't have separate data for e.g. FlatLoad_16_7
+        if occursin("FlatLoad", buildingtype)
+            annual_mmbtu = dhw_annual_mmbtu[city]["FlatLoad"]
+        else        
+            annual_mmbtu = dhw_annual_mmbtu[city][buildingtype]
+        end
     end
     if length(monthly_mmbtu) == 12
         monthly_mmbtu = convert(Vector{Real}, monthly_mmbtu)
@@ -1033,7 +1038,12 @@ function BuiltInSpaceHeatingLoad(
         error("buildingtype $(buildingtype) not in $(default_buildings).")
     end
     if isnothing(annual_mmbtu)
-        annual_mmbtu = spaceheating_annual_mmbtu[city][buildingtype]
+        # Use FlatLoad annual_mmbtu from data for all types of FlatLoads because we don't have separate data for e.g. FlatLoad_16_7
+        if occursin("FlatLoad", buildingtype)
+            annual_mmbtu = spaceheating_annual_mmbtu[city]["FlatLoad"]
+        else
+            annual_mmbtu = spaceheating_annual_mmbtu[city][buildingtype]
+        end
     end
     built_in_load("space_heating", city, buildingtype, year, annual_mmbtu, monthly_mmbtu)
 end
@@ -1366,7 +1376,12 @@ function BuiltInCoolingLoad(
         existing_chiller_cop = get_existing_chiller_default_cop()
     end
     if isnothing(annual_tonhour)
-        annual_kwh = cooling_annual_kwh[city][buildingtype]
+        # Use FlatLoad annual_kwh from data for all types of FlatLoads because we don't have separate data for e.g. FlatLoad_16_7
+        if occursin("FlatLoad", buildingtype)
+            annual_kwh = cooling_annual_kwh[city]["FlatLoad"]
+        else
+            annual_kwh = cooling_annual_kwh[city][buildingtype]
+        end
     else
         annual_kwh = annual_tonhour * KWH_THERMAL_PER_TONHOUR / existing_chiller_cop
     end

--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -341,6 +341,19 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
                                     time_steps_per_hour=settings.time_steps_per_hour
                                     )
         max_cooling_demand_kw = maximum(cooling_load.loads_kw_thermal)
+    
+        # Check if cooling electric load is greater than total electric load in any hour, and throw error if true with the violating time time_steps
+        cooling_elec = cooling_load.loads_kw_thermal / cooling_load.existing_chiller_cop
+        cooling_elec_too_high_timesteps = findall(cooling_elec .> electric_load.loads_kw)
+        if length(cooling_elec_too_high_timesteps) > 0
+            cooling_elec_too_high_kw = cooling_elec[cooling_elec_too_high_timesteps]
+            total_elec_when_cooling_elec_too_high = electric_load.loads_kw[cooling_elec_too_high_timesteps]
+            error("Cooling electric consumption cannot be more than the total electric load at any time step. At time steps 
+                $cooling_elec_too_high_timesteps the cooling electric consumption is $cooling_elec_too_high_kw (kW) and
+                the total electric load is $total_elec_when_cooling_elec_too_high (kW). Note you may consider adjusting 
+                cooling load input versus the total electric load if you provided inputs in units of cooling tons, or 
+                check the electric chiller COP input value.")
+        end
     else
         cooling_load = CoolingLoad(; 
             thermal_loads_ton=zeros(8760*settings.time_steps_per_hour),

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -290,7 +290,7 @@ function generate_year_profile_hourly(year::Int64, consecutive_periods::Abstract
     if Dates.isleapyear(year)
         end_year_datetime = DateTime(string(year)*"-12-30T23:00:00")
     else
-        end_year_datetime = DateTime(string(year+1)*"-12-31T23:00:00")
+        end_year_datetime = DateTime(string(year)*"-12-31T23:00:00")
     end
 
     dt_hourly = collect(DateTime(string(year)*"-01-01T00:00:00"):Hour(1):end_year_datetime)

--- a/test/scenarios/chp_unavailability_outage.json
+++ b/test/scenarios/chp_unavailability_outage.json
@@ -27,6 +27,9 @@
     "DomesticHotWaterLoad": {
         "doe_reference_name": "Hospital"
     },
+    "CoolingLoad": {
+        "doe_reference_name": "Hospital"
+    },
     "ExistingBoiler": {
         "fuel_cost_per_mmbtu": 5.0
     },

--- a/test/scenarios/flatloads.json
+++ b/test/scenarios/flatloads.json
@@ -1,0 +1,27 @@
+{
+    "Site": {
+        "latitude": 37.78, 
+        "longitude": -122.45
+    },
+    "ElectricLoad": {
+        "doe_reference_name": "FlatLoad_16_7"
+    },
+    "ElectricTariff": {
+        "blended_annual_energy_rate": 0.06,
+        "blended_annual_demand_rate": 0.0
+    },
+    "SpaceHeatingLoad": {
+        "doe_reference_name": "FlatLoad_8_5"
+    },
+    "DomesticHotWaterLoad": {
+        "doe_reference_name": "FlatLoad_8_5"
+    },
+    "ExistingBoiler": {
+        "fuel_cost_per_mmbtu": [11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11],
+        "efficiency": 0.8
+    },
+    "CoolingLoad": {
+        "annual_tonhour": 10000.0,
+        "doe_reference_name": "FlatLoad_8_5"
+    }
+}


### PR DESCRIPTION
This PR addresses:

- Issue 1: schedule-based flat loads, see [page 37 of the REopt manual](https://reopt.nrel.gov/tool/reopt-user-manual.pdf) for a description of these load options which are available in the API
- Issue 2: addressable load fraction input for heating loads, see [page 38 of the REopt manual](https://reopt.nrel.gov/tool/reopt-user-manual.pdf) for a description of how addressable load fraction reduces the `fuel` energy input by the user for the portion of the space heating or domestic hot water that is addressable by heating technologies such as `CHP`, `ExistingBoiler`, and `GHP`. The "non-addressable" part of the load is *discarded* in the accounting of fuel and heat.
- A validation that must occur within `scenario.jl` to check that cooling electric is less than total electric