### PR TITLE
Change default wind operating reserve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
-# REopt Changelog
+# Changelog
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Guidelines
+- When making a Pull Request into `develop` start a new double-hash header for "Develop - YYYY-MM-DD"
+- When making a Pull Request into `master` change "Develop" to the next version number
+
+### Formatting
+- Use **bold** markup for field and model names (i.e. **outage_start_time_step**)
+- Use `code` markup for  REopt-specific file names, classes and endpoints (e.g. `src/REopt.jl`)
+- Use _italic_ for code terms (i.e. _list_)
+- Prepend change with tag(s) directing where it is in the repository:  
+`src`,`constraints`,`*.jl`
+
+Classify the change according to the following categories:
+    
+    ### Major Updates
+    ### Minor Updates
+    ##### Added
+    ##### Changed
+    ##### Fixed
+    ##### Deprecated
+    ##### Removed
+    ### Patches
 ## Develop
 ### Changed
 - Change default value for `wind.jl` `operating_reserve_required_pct` from 0.1 to 0.5 (only applicable when off_grid_flag=True.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # REopt Changelog
+
+## Develop
+### Changed
+- Change default value for `wind.jl` `operating_reserve_required_pct` from 0.1 to 0.5 (only applicable when off_grid_flag=True.)
+
 ## Develop
 ### Changed
 - Don't trigger GitHub 'Run test' workflow on a push that only changes README.md and/or CHANGELOG.md

--- a/src/core/electric_utility.jl
+++ b/src/core/electric_utility.jl
@@ -56,7 +56,7 @@
     CO2_emissions_reduction_max_pct::Union{Real, Nothing} = nothing, # passed from Site
     include_climate_in_objective::Bool = false, # passed from Settings
     include_health_in_objective::Bool = false # passed from Settings
-```julia
+```
 
 !!! note "Outage modeling"
     Outage indexing begins at 1 (not 0) and the outage is inclusive of the outage end time step. 

--- a/src/core/flexible_hvac.jl
+++ b/src/core/flexible_hvac.jl
@@ -48,7 +48,7 @@ end
     temperature_upper_bound_degC::Union{Real, Nothing}
     temperature_lower_bound_degC::Union{Real, Nothing}
     installed_cost::Float64
-```julia
+```
 
 Every model with `FlexibleHVAC` includes a preprocessing step to calculate the business-as-usual (BAU)
 cost of meeting the thermal loads using a dead-band controller. The BAU cost is then used in the 

--- a/src/core/wind.jl
+++ b/src/core/wind.jl
@@ -60,6 +60,7 @@
     can_net_meter = true,
     can_wholesale = true,
     can_export_beyond_nem_limit = true
+    operating_reserve_required_pct::Real = off_grid_flag ? 0.50 : 0.0, # Only applicable when off_grid_flag is True. Applied to each time_step as a % of wind generation serving load.
 ```
 
 `size_class` must be one of ["residential", "commercial", "medium", "large"]. If `size_class` is not provided then it is determined based on the average electric load.
@@ -163,7 +164,7 @@ struct Wind <: AbstractTech
         can_export_beyond_nem_limit = off_grid_flag ? false : true,
         can_curtail= true,
         average_elec_load = 0.0,
-        operating_reserve_required_pct::Real = off_grid_flag ? 0.10 : 0.0, # TODO determine appropriate value. if off grid, 10%, else 0%. Applied to each time_step as a % of wind generation.
+        operating_reserve_required_pct::Real = off_grid_flag ? 0.50 : 0.0, # Only applicable when off_grid_flag is True. Applied to each time_step as a % of wind generation serving load.
         )
         size_class_to_hub_height = Dict(
             "residential"=> 20,


### PR DESCRIPTION
Previously the wind.jl `operating_reserve_required_pct` was 10% (as a placeholder). Updating to 50% based on https://wwf.ca/wp-content/uploads/2020/03/Fuelling-change-in-the-arctic_2016.pdf. (This value is largely a user preference, and only applies when `off_grid_flag=True`). 

Also update `CHANGELOG.md` with general instructions (ported over from REopt_API) 