### PR TITLE
Abs chill mods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,10 @@ Classify the change according to the following categories:
 ### Changed
 - Change default value for `wind.jl` **operating_reserve_required_pct** from 0.1 to 0.5 (only applicable when **off_grid_flag**=_True_.)
 - allow user to specify emissions_region in ElectricUtility, which is used instead of lat/long to look up AVERT data if emissions factors aren't provided by the user
+- Updated results keys in `results/absorption_chiller.jl`
 ### Fixed
 - Add **wholesale_rate** and **emissions_factor_series_lb_\<pollutant\>_per_kwh** inputs to the list of inputs that `dictkeys_tosymbols()` tries to convert to type _Array{Real}_. Due to serialization, when list inputs come from the API, they are of type _Array{Any}_ so must be converted to match type required by the constructors they are passed to.
+- Fixed bug in calcuation of power delivered to cold thermal storage by the electric chiller in `results/existing_chiller.jl`.
 
 ## v0.17.0
 ### Added

--- a/src/core/absorption_chiller.jl
+++ b/src/core/absorption_chiller.jl
@@ -33,8 +33,8 @@
 ```julia
     min_ton::Real = 0.0,
     max_ton::Real = 0.0,
-    chiller_cop::Real,
-    chiller_elec_cop::Real = 14.1,
+    cop_thermal::Real,
+    cop_electric::Real = 14.1,
     installed_cost_per_ton::Real,
     om_cost_per_ton::Real,
     macrs_option_years::Real = 0,
@@ -44,8 +44,8 @@
 struct AbsorptionChiller <: AbstractThermalTech
     min_ton::Real
     max_ton::Real
-    chiller_cop::Real
-    chiller_elec_cop::Real
+    cop_thermal::Real
+    cop_electric::Real
     installed_cost_us_dollars_per_ton::Real
     om_cost_us_dollars_per_ton::Real
     macrs_option_years::Real
@@ -57,8 +57,8 @@ struct AbsorptionChiller <: AbstractThermalTech
     function AbsorptionChiller(;
         min_ton::Real = 0.0,
         max_ton::Real = 0.0,
-        chiller_cop::Real,
-        chiller_elec_cop::Real = 14.1,
+        cop_thermal::Real,
+        cop_electric::Real = 14.1,
         installed_cost_per_ton::Real,
         om_cost_per_ton::Real,
         macrs_option_years::Real = 0,
@@ -73,8 +73,8 @@ struct AbsorptionChiller <: AbstractThermalTech
         new(
             min_ton,
             max_ton,
-            chiller_cop,
-            chiller_elec_cop,
+            cop_thermal,
+            cop_electric,
             installed_cost_per_ton,
             om_cost_per_ton,
             macrs_option_years,

--- a/src/core/heating_cooling_loads.jl
+++ b/src/core/heating_cooling_loads.jl
@@ -339,21 +339,25 @@ struct CoolingLoad
                 or the site_electric_load_profile along with one of [per_time_step_fractions_of_electric_load, monthly_fractions_of_electric_load, annual_fraction_of_electric_load].")
         end
 
-        # Now that either the cooling electric loads_kw or the cooling thermal loads_kw_thermal is known, update existing_chiller_cop if it was not input
-        if isnothing(existing_chiller_cop)
-            existing_chiller_cop = get_existing_chiller_default_cop(;existing_chiller_max_thermal_factor_on_peak_load=existing_chiller_max_thermal_factor_on_peak_load,
-                                loads_kw=loads_kw, loads_kw_thermal=loads_kw_thermal)
-        end
-
         if isnothing(loads_kw_thermal)  # have to convert electric loads_kw to thermal load
-            if !isnothing(annual_tonhour) || !isempty(monthly_tonhour)
+            if (!isnothing(annual_tonhour) || !isempty(monthly_tonhour)) && isnothing(existing_chiller_cop)
                 # cop_unknown_thermal (4.55) was used to convert thermal to electric in BuiltInCoolingLoad, so need to use the same here to convert back
                 #  in order to preserve the input tonhour amounts - however, the updated/actual existing_chiller_cop is still assigned based on user input or actual max ton load conditional defaults
                 chiller_cop = get_existing_chiller_default_cop()
+            elseif (!isempty(doe_reference_name) || !isempty(blended_doe_reference_names)) || isnothing(existing_chiller_cop)
+                # Generated loads_kw (electric) above based on the building's default fraction of electric profile
+                chiller_cop = get_existing_chiller_default_cop(;existing_chiller_max_thermal_factor_on_peak_load=existing_chiller_max_thermal_factor_on_peak_load, 
+                                        loads_kw=loads_kw)
             else
                 chiller_cop = existing_chiller_cop
             end
             loads_kw_thermal = chiller_cop * loads_kw
+        end
+
+        # Now that cooling thermal loads_kw_thermal is known, update existing_chiller_cop if it was not input
+        if isnothing(existing_chiller_cop)
+            existing_chiller_cop = get_existing_chiller_default_cop(;existing_chiller_max_thermal_factor_on_peak_load=existing_chiller_max_thermal_factor_on_peak_load, 
+                                        loads_kw_thermal=loads_kw_thermal)
         end
 
         if length(loads_kw_thermal) < 8760*time_steps_per_hour

--- a/src/core/reopt_inputs.jl
+++ b/src/core/reopt_inputs.jl
@@ -651,6 +651,11 @@ function setup_absorption_chiller_inputs(s::AbstractScenario, max_sizes, min_siz
     end
 
     cop["AbsorptionChiller"] = s.absorption_chiller.cop_electric
+    if isnothing(s.chp)
+        thermal_factor = 1.0
+    else
+        thermal_factor = s.chp.cooling_thermal_factor
+    end    
     thermal_cop["AbsorptionChiller"] = s.absorption_chiller.cop_thermal * thermal_factor
     om_cost_per_kw["AbsorptionChiller"] = s.absorption_chiller.om_cost_per_kw
     return nothing

--- a/src/core/reopt_inputs.jl
+++ b/src/core/reopt_inputs.jl
@@ -653,6 +653,9 @@ function setup_absorption_chiller_inputs(s::AbstractScenario, max_sizes, min_siz
     cop["AbsorptionChiller"] = s.absorption_chiller.cop_electric
     if isnothing(s.chp)
         thermal_factor = 1.0
+    elseif s.chp.cooling_thermal_factor == 0.0
+        error("The CHP cooling_thermal_factor is 0.0 which implies that CHP cannot serve AbsorptionChiller. If you
+            want to model CHP and AbsorptionChiller, you must specify a cooling_thermal_factor greater than 0.0")
     else
         thermal_factor = s.chp.cooling_thermal_factor
     end    

--- a/src/core/reopt_inputs.jl
+++ b/src/core/reopt_inputs.jl
@@ -650,8 +650,8 @@ function setup_absorption_chiller_inputs(s::AbstractScenario, max_sizes, min_siz
         cap_cost_slope["AbsorptionChiller"] = s.absorption_chiller.installed_cost_per_kw
     end
 
-    cop["AbsorptionChiller"] = s.absorption_chiller.chiller_elec_cop
-    thermal_cop["AbsorptionChiller"] = s.absorption_chiller.chiller_cop
+    cop["AbsorptionChiller"] = s.absorption_chiller.cop_electric
+    thermal_cop["AbsorptionChiller"] = s.absorption_chiller.cop_thermal * thermal_factor
     om_cost_per_kw["AbsorptionChiller"] = s.absorption_chiller.om_cost_per_kw
     return nothing
 end

--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -80,6 +80,7 @@ All values of `d` are expected to be `Dicts` except for `PV` and `GHP`, which ca
     handle conversion of Vector of Vectors from JSON to a Matrix in Julia).
 """
 function Scenario(d::Dict; flex_hvac_from_json=false)
+    d = deepcopy(d)
     if haskey(d, "Settings")
         settings = Settings(;dictkeys_tosymbols(d["Settings"])...)
     else

--- a/src/results/absorption_chiller.jl
+++ b/src/results/absorption_chiller.jl
@@ -51,27 +51,27 @@ function add_absorption_chiller_results(m::JuMP.AbstractModel, p::REoptInputs, d
 
 	r["size_kw"] = value(sum(m[:dvSize][t] for t in p.techs.absorption_chiller))
 	r["size_ton"] = r["size_kw"] / KWH_THERMAL_PER_TONHOUR
-	@expression(m, ABSORPCHLtoTES[ts in p.time_steps],
+	@expression(m, ABSORPCHLtoTESKW[ts in p.time_steps],
 		sum(m[:dvProductionToStorage][b,t,ts] for b in p.s.storage.types.cold, t in p.techs.absorption_chiller))
-	r["year_one_to_tes_series_ton"] = round.(value.(ABSORPCHLtoTES / KWH_THERMAL_PER_TONHOUR), digits=3)
-	@expression(m, ABSORPCHLtoLoad[ts in p.time_steps],
+	r["year_one_to_tes_series_ton"] = round.(value.(ABSORPCHLtoTESKW) ./ KWH_THERMAL_PER_TONHOUR, digits=5)
+	@expression(m, ABSORPCHLtoLoadKW[ts in p.time_steps],
 		sum(m[:dvThermalProduction][t,ts] for t in p.techs.absorption_chiller)
-			- ABSORPCHLtoTES[ts]) 
-	r["year_one_to_load_series_ton"] = round.(value.(ABSORPCHLtoLoad / KWH_THERMAL_PER_TONHOUR), digits=3)
-	@expression(m, ABSORPCHLThermalConsumptionSeries[ts in p.time_steps],
-		sum(m[:dvThermalProduction][t,ts] / p.thermal_cop[t] for t in p.techs.absorption_chiller) / KWH_THERMAL_PER_TONHOUR)
-	r["year_one_thermal_consumption_series"] = round.(value.(ABSORPCHLThermalConsumptionSeries), digits=3)
-	@expression(m, Year1ABSORPCHLThermalConsumption,
+			- ABSORPCHLtoTESKW[ts]) 
+	r["year_one_to_load_series_ton"] = round.(value.(ABSORPCHLtoLoadKW) ./ KWH_THERMAL_PER_TONHOUR, digits=5)
+	@expression(m, ABSORPCHLThermalConsumptionSeriesKW[ts in p.time_steps],
+		sum(m[:dvThermalProduction][t,ts] / p.thermal_cop[t] for t in p.techs.absorption_chiller))
+	r["year_one_thermal_consumption_series_mmbtu_per_hour"] = round.(value.(ABSORPCHLThermalConsumptionSeriesKW) ./ KWH_PER_MMBTU, digits=5)
+	@expression(m, Year1ABSORPCHLThermalConsumptionKWH,
 		p.hours_per_time_step * sum(m[:dvThermalProduction][t,ts] / p.thermal_cop[t]
 			for t in p.techs.absorption_chiller, ts in p.time_steps))
-	r["year_one_thermal_consumption_kwh"] = round(value(Year1ABSORPCHLThermalConsumption), digits=3)
-	@expression(m, Year1ABSORPCHLThermalProd,
+	r["year_one_thermal_consumption_mmbtu"] = round(value(Year1ABSORPCHLThermalConsumptionKWH) / KWH_PER_MMBTU, digits=5)
+	@expression(m, Year1ABSORPCHLThermalProdKWH,
 		p.hours_per_time_step * sum(m[:dvThermalProduction][t, ts]
 			for t in p.techs.absorption_chiller, ts in p.time_steps))
-	r["year_one_thermal_production_tonhour"] = round(value(Year1ABSORPCHLThermalProd / KWH_THERMAL_PER_TONHOUR), digits=3)
+	r["year_one_thermal_production_tonhour"] = round(value(Year1ABSORPCHLThermalProdKWH) / KWH_THERMAL_PER_TONHOUR, digits=5)
     @expression(m, ABSORPCHLElectricConsumptionSeries[ts in p.time_steps],
         sum(m[:dvThermalProduction][t,ts] / p.cop[t] for t in p.techs.absorption_chiller) )
-    r["year_one_electric_consumption_series"] = round.(value.(ABSORPCHLElectricConsumptionSeries), digits=3)
+    r["year_one_electric_consumption_series_kw"] = round.(value.(ABSORPCHLElectricConsumptionSeries), digits=3)
     @expression(m, Year1ABSORPCHLElectricConsumption,
         p.hours_per_time_step * sum(m[:dvThermalProduction][t,ts] / p.cop[t] 
             for t in p.techs.absorption_chiller, ts in p.time_steps))

--- a/src/results/existing_boiler.jl
+++ b/src/results/existing_boiler.jl
@@ -29,11 +29,11 @@
 # *********************************************************************************
 """
 `ExistingBoiler` results keys:
-- `year_one_fuel_consumption_mmbtu_per_hour` 
+- `year_one_fuel_consumption_series_mmbtu_per_hour` 
 - `year_one_fuel_consumption_mmbtu`
-- `year_one_thermal_production_mmbtu_per_hour`
+- `year_one_thermal_production_series_mmbtu_per_hour`
 - `year_one_thermal_production_mmbtu`
-- `thermal_to_tes_series_mmbtu_per_hour`
+- `year_one_thermal_to_tes_series_mmbtu_per_hour`
 - `year_one_thermal_to_load_series_mmbtu_per_hour`
 - `lifecycle_fuel_cost_after_tax`
 - `year_one_fuel_cost_before_tax`
@@ -41,15 +41,13 @@
 function add_existing_boiler_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
     r = Dict{String, Any}()
 
-    # TODO all of these time series assume hourly time steps
-    # TODO we convert KWH_PER_MMBTU from user inputs to the model, and then back to mmbtu in outputs: why not stay in mmbtu?
-	r["year_one_fuel_consumption_mmbtu_per_hour"] = 
-        round.(value.(m[:dvFuelUsage]["ExistingBoiler", ts] for ts in p.time_steps) / KWH_PER_MMBTU, digits=5)
-    r["year_one_fuel_consumption_mmbtu"] = round(sum(r["year_one_fuel_consumption_mmbtu_per_hour"]), digits=3)
+	r["year_one_fuel_consumption_series_mmbtu_per_hour"] = 
+        round.(value.(m[:dvFuelUsage]["ExistingBoiler", ts] for ts in p.time_steps) ./ KWH_PER_MMBTU, digits=5)
+    r["year_one_fuel_consumption_mmbtu"] = round(sum(r["year_one_fuel_consumption_series_mmbtu_per_hour"]), digits=5)
 
-	r["year_one_thermal_production_mmbtu_per_hour"] = 
-        round.(value.(m[:dvThermalProduction]["ExistingBoiler", ts] for ts in p.time_steps) / KWH_PER_MMBTU, digits=5)
-	r["year_one_thermal_production_mmbtu"] = round(sum(r["year_one_thermal_production_mmbtu_per_hour"]), digits=3)
+	r["year_one_thermal_production_series_mmbtu_per_hour"] = 
+        round.(value.(m[:dvThermalProduction]["ExistingBoiler", ts] for ts in p.time_steps) ./ KWH_PER_MMBTU, digits=5)
+	r["year_one_thermal_production_mmbtu"] = round(sum(r["year_one_thermal_production_series_mmbtu_per_hour"]), digits=5)
 
 	if !isempty(p.s.storage.types.hot)
         @expression(m, BoilerToHotTESKW[ts in p.time_steps],
@@ -58,20 +56,20 @@ function add_existing_boiler_results(m::JuMP.AbstractModel, p::REoptInputs, d::D
     else
         BoilerToHotTESKW = zeros(length(p.time_steps))
     end
-	r["thermal_to_tes_series_mmbtu_per_hour"] = round.(value.(BoilerToHotTESKW / KWH_PER_MMBTU), digits=3)
+	r["year_one_thermal_to_tes_series_mmbtu_per_hour"] = round.(value.(BoilerToHotTESKW ./ KWH_PER_MMBTU), digits=5)
 
-    # if !isempty(p.SteamTurbineTechs)
-    #     @expression(m, BoilerToSteamTurbine[ts in p.time_steps], m[:dvThermalToSteamTurbine]["ExistingBoiler",ts])
+    # if !isempty(p.techs.steam_turbine)
+    #     @expression(m, BoilerToSteamTurbineKW[ts in p.time_steps], m[:dvThermalToSteamTurbine]["ExistingBoiler",ts])
     # else
-    #     @expression(m, BoilerToSteamTurbine[ts in p.time_steps], 0.0)
+    #     @expression(m, BoilerToSteamTurbineKW[ts in p.time_steps], 0.0)
     # end
-    # r["boiler_thermal_to_steamturbine_series"] = round.(value.(BoilerToSteamTurbine), digits=3)
+    # r["year_one_thermal_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(BoilerToSteamTurbineKW) ./ KWH_PER_MMBTU, digits=5)
 
 
-	@expression(m, BoilerToLoad[ts in p.time_steps],
-		m[:dvThermalProduction]["ExistingBoiler",ts] - BoilerToHotTESKW[ts] #- BoilerToSteamTurbine[ts]
+	BoilerToLoadKW = @expression(m, [ts in p.time_steps],
+		m[:dvThermalProduction]["ExistingBoiler",ts] - BoilerToHotTESKW[ts] #- BoilerToSteamTurbineKW[ts]
     )
-	r["year_one_thermal_to_load_series_mmbtu_per_hour"] = round.(value.(BoilerToLoad / KWH_PER_MMBTU), digits=5)
+	r["year_one_thermal_to_load_series_mmbtu_per_hour"] = round.(value.(BoilerToLoadKW ./ KWH_PER_MMBTU), digits=5)
 
 	r["lifecycle_fuel_cost_after_tax"] = round(value(m[:TotalExistingBoilerFuelCosts]) * (1 - p.s.financial.offtaker_tax_pct), digits=3)
 	r["year_one_fuel_cost_before_tax"] = round(value(m[:TotalExistingBoilerFuelCosts]) / p.pwf_fuel["ExistingBoiler"], digits=3)

--- a/src/results/existing_chiller.jl
+++ b/src/results/existing_chiller.jl
@@ -39,7 +39,7 @@ function add_existing_chiller_results(m::JuMP.AbstractModel, p::REoptInputs, d::
     r = Dict{String, Any}()
 
 	@expression(m, ELECCHLtoTES[ts in p.time_steps],
-		sum(m[:dvProductionToStorage][b,"ExistingChiller",ts] for b in p.s.storage.types.cold, t in p.techs.cooling)
+		sum(m[:dvProductionToStorage][b,"ExistingChiller",ts] for b in p.s.storage.types.cold)
     )
 	r["year_one_to_tes_series_ton"] = round.(value.(ELECCHLtoTES / KWH_THERMAL_PER_TONHOUR), digits=3)   
 

--- a/test/scenarios/heat_cool_energy_balance_inputs.json
+++ b/test/scenarios/heat_cool_energy_balance_inputs.json
@@ -37,7 +37,8 @@
             ]         
     },
     "ExistingChiller": {
-        "cop": 3.4
+        "cop": 3.4,
+        "max_thermal_factor_on_peak_load": 1.25
     },
     "CHP": {
         "prime_mover": "recip_engine" ,
@@ -67,15 +68,25 @@
         "max_kwh": 0.0
     },
     "HotThermalStorage":{
-        "min_gal": 30000.0,
-        "max_gal": 30000.0,
-        "internal_efficiency_pct": 0.97,
-        "thermal_decay_rate_fraction": 0.004
-    },
-    "ColdThermalStorage":{
         "min_gal": 20000.0,
         "max_gal": 20000.0,
         "internal_efficiency_pct": 0.97,
         "thermal_decay_rate_fraction": 0.004
-    }    
+    },
+    "ColdThermalStorage":{
+        "min_gal": 30000.0,
+        "max_gal": 30000.0,
+        "internal_efficiency_pct": 0.97,
+        "thermal_decay_rate_fraction": 0.004,
+        "soc_init_pct": 0.1
+    },
+    "AbsorptionChiller": {
+        "min_ton": 400.0,
+        "max_ton": 400.0,
+        "cop_thermal": 0.7,
+        "installed_cost_per_ton": 500.0,
+        "om_cost_per_ton": 0.5,
+        "macrs_option_years": 0,
+        "macrs_bonus_pct": 0.0
+      }    
 }

--- a/test/scenarios/re_emissions_with_thermal.json
+++ b/test/scenarios/re_emissions_with_thermal.json
@@ -83,7 +83,7 @@
   "AbsorptionChiller": {
     "min_ton": 400.0 ,
     "max_ton": 400.0 ,
-    "chiller_cop": 0.7 ,
+    "cop_thermal": 0.7 ,
     "installed_cost_per_ton": 500.0 ,
     "om_cost_per_ton": 0.5 ,
     "macrs_option_years": 0 ,

--- a/test/scenarios/thermal_storage.json
+++ b/test/scenarios/thermal_storage.json
@@ -26,7 +26,7 @@
     "AbsorptionChiller": {
         "min_ton": 0.0,
         "max_ton": 1000.0,
-        "chiller_cop": 0.7,
+        "cop_thermal": 0.7,
         "installed_cost_per_ton": 500.0,
         "om_cost_per_ton": 0.5,
         "macrs_option_years": 0,

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -658,11 +658,11 @@ end
     """
 
     This is an "energy balance" type of test which tests the model formulation/math as opposed
-        to a specific scenario. This test is robust to changes in the model "MIPRELSTOP" or "MAXTIME" setting
+    to a specific scenario. This test is robust to changes in the model "MIPRELSTOP" or "MAXTIME" setting
 
     Validation to ensure that:
-        1) The electric chiller [TODO and absorption chiller] are supplying 100% of the cooling thermal load
-        2) The boiler is supplying the boiler heating load [TODO plus additional absorption chiller thermal load]
+        1) The electric and absorption chillers are supplying 100% of the cooling thermal load plus losses from ColdThermalStorage
+        2) The boiler and CHP are supplying the heating load plus additional absorption chiller thermal load
         3) The Cold and Hot TES efficiency (charge loss and thermal decay) are being tracked properly
 
     """

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -1055,7 +1055,7 @@ end
     @test round(heating_served_mmbtu, digits=1) ≈ expected_heating_served_mmbtu atol=1.0
     
     # Boiler serves all of the DHW load, no DHW thermal reduction due to GHP retrofit
-    boiler_served_mmbtu = sum(results["ExistingBoiler"]["year_one_thermal_production_mmbtu_per_hour"])
+    boiler_served_mmbtu = sum(results["ExistingBoiler"]["year_one_thermal_production_series_mmbtu_per_hour"])
     expected_boiler_served_mmbtu = 3000 * 0.8 # (fuel_mmbtu * boiler_effic)
     @test round(boiler_served_mmbtu, digits=1) ≈ expected_boiler_served_mmbtu atol=1.0
     

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -699,7 +699,7 @@ end
     # absorpchl_total_cooling_produced_series_ton = [cooling_absorpchl_tons_to_load_series[i] + cooling_absorpchl_tons_to_tes_series[i] for i in range(8760)] 
     # absorpchl_total_cooling_produced_ton_hour = sum(absorpchl_total_cooling_produced_series_ton)
     # absorpchl_electric_consumption_total_kwh = results["AbsorptionChiller"]["year_one_absorp_chl_electric_consumption_kwh"]
-    # absorpchl_cop_elec = inputs["AbsorptionChiller"]["chiller_elec_cop"]
+    # absorpchl_cop_elec = inputs["AbsorptionChiller"]["cop_electric"]
 
     # Check if sum of electric and absorption chillers equals cooling thermal total
     @test tes_effic_with_decay < 0.97


### PR DESCRIPTION
After `AbsorptionChiller` was uncommented from @testset "Heat and cool energy balance", the first test for "cooling production from techs equals the cooling load plus TES losses" is failing. The test is showing that there is excessive amounts of TES losses (TES charge energy minus TES discharge energy), and the techs are not supplying that extra loss. When `AbsorptionChiller` is not included in the test, the model is not showing these excessive losses, so somehow the `AbsorptionChiller` is allowing unserved TES losses.

Note that I changed some variable naming, and the Hot and Cold TES sizes for this test, but that is not consequential to the test result because it's an energy balance test.