### PR TITLE
Add CHP and SteamTurbine defaults logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## Develop
+### Changed
+For `CHP` and `SteamTurbine`, the `prime_mover` and/or `size_class` is chosen (if not input) based on the average heating load and the type of heating load (hot water or steam).
+ - This logic replicates the current REopt webtool behavior which was implemented based on CHP industry experts, effectively syncing the webtool and the REopt.jl/API behavior.
+ - This makes `prime_mover` **NOT** a required input and avoids a lot of other required inputs if `prime_mover` is not input.
+ - The two functions made for `CHP` and `SteamTurbine` are exported in `REopt.jl` so they can be exposed in the API for communication with the webtool (or other API users).
+### Removed 
+`ExistingBoiler.production_type_by_chp_prime_mover` because that is no longer consistent with the logic added above.
+ - The logic from 1. is such that `ExistingBoiler.production_type` determines the `CHP.prime_mover` if not specified, not the other way around.
+ - If `ExistingBoiler.production_type` is not input, `hot_water` is used as the default.
 ## v0.20.1
 ### Added
 - `CoolingLoad` time series and annual summary data to results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
-## Develop
+## v0.21.0
 ### Changed
 For `CHP` and `SteamTurbine`, the `prime_mover` and/or `size_class` is chosen (if not input) based on the average heating load and the type of heating load (hot water or steam).
  - This logic replicates the current REopt webtool behavior which was implemented based on CHP industry experts, effectively syncing the webtool and the REopt.jl/API behavior.
@@ -33,6 +33,7 @@ For `CHP` and `SteamTurbine`, the `prime_mover` and/or `size_class` is chosen (i
 `ExistingBoiler.production_type_by_chp_prime_mover` because that is no longer consistent with the logic added above.
  - The logic from 1. is such that `ExistingBoiler.production_type` determines the `CHP.prime_mover` if not specified, not the other way around.
  - If `ExistingBoiler.production_type` is not input, `hot_water` is used as the default.
+
 ## v0.20.1
 ### Added
 - `CoolingLoad` time series and annual summary data to results

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "REopt"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
 authors = ["Nick Laws", "Hallie Dunham <hallie.dunham@nrel.gov>", "Bill Becker <william.becker@nrel.gov>", "Bhavesh Rathod <bhavesh.rathod@nrel.gov>", "Alex Zolan <alexander.aolan@nrel.gov>", "Amanda Farthing <amanda.farthing@nrel.gov>"]
-version = "0.20.1"
+version = "0.21.0"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/REopt.jl
+++ b/src/REopt.jl
@@ -44,7 +44,9 @@ export
     MPCInputs,
     run_mpc,
     build_mpc!, 
-    backup_reliability
+    backup_reliability,
+    get_chp_defaults_prime_mover_size_class,
+    get_steam_turbine_defaults_size_class
 
 import HTTP
 import JSON

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -33,15 +33,15 @@ prime_movers = ["recip_engine", "micro_turbine", "combustion_turbine", "fuel_cel
 """
 `CHP` is an optional REopt input with the following keys and default values:
 ```julia
-    prime_mover::String = ""
-    fuel_cost_per_mmbtu::Union{<:Real, AbstractVector{<:Real}} = []  # REQUIRED
+    prime_mover::Union{String, Nothing} = nothing Suggested to inform applicable default cost and performance
+    fuel_cost_per_mmbtu::Union{<:Real, AbstractVector{<:Real}} = []  REQUIRED
 
     # Required "custom inputs" if not providing prime_mover:
     installed_cost_per_kw::Union{Float64, AbstractVector{Float64}} = NaN
     tech_sizes_for_cost_curve::Union{Float64, AbstractVector{Float64}} = NaN
     om_cost_per_kwh::Float64 = NaN
-    electric_efficiency_half_load = NaN
     electric_efficiency_full_load::Float64 = NaN
+    electric_efficiency_half_load::Float64 = NaN
     min_turn_down_fraction::Float64 = NaN
     thermal_efficiency_full_load::Float64 = NaN
     thermal_efficiency_half_load::Float64 = NaN
@@ -51,7 +51,7 @@ prime_movers = ["recip_engine", "micro_turbine", "combustion_turbine", "fuel_cel
     unavailability_periods::AbstractVector{Dict} = Dict[]
 
     # Optional inputs:
-    size_class::Int = 1
+    size_class::Union{Int, Nothing} = nothing
     min_kw::Float64 = 0.0
     fuel_type::String = "natural_gas" # "restrict_to": ["natural_gas", "landfill_bio_gas", "propane", "diesel_oil"]
     om_cost_per_kw::Float64 = 0.0
@@ -91,24 +91,22 @@ prime_movers = ["recip_engine", "micro_turbine", "combustion_turbine", "fuel_cel
     emissions_factor_lb_PM25_per_mmbtu::Float64 = FUEL_DEFAULTS["emissions_factor_lb_PM25_per_mmbtu"][fuel_type]
 ```
 
-!!! note "Required inputs"
-    To model CHP, you must provide at least `prime_mover` from $(prime_movers) or all of the "custom inputs" defined below.
-    If prime_mover is provided, any missing value from the "custom inputs" will be populated from data/chp/chp_default_data.json, 
-    based on the prime_mover, boiler_type, and size_class. boiler_type is "steam" if `prime_mover` is "combustion_turbine" 
-    and is "hot_water" for all other `prime_mover` types.
+!!! note defaults and "Required inputs"
+    See the `get_chp_defaults_prime_mover_size_class()` function docstring for details on the logic of choosing the type of CHP that is modeled
+    If no information is provided, the default `prime_mover` is `recip_engine` and the `size_class` is 1 which represents
+    the widest range of sizes available.
 
     `fuel_cost_per_mmbtu` is always required
 
 """
 Base.@kwdef mutable struct CHP <: AbstractCHP
-    prime_mover::String = ""
+    prime_mover::Union{String, Nothing} = nothing
     fuel_cost_per_mmbtu::Union{<:Real, AbstractVector{<:Real}} = []    
-    # following must be provided by user if not providing prime_mover
     installed_cost_per_kw::Union{Float64, AbstractVector{Float64}} = Float64[]
     tech_sizes_for_cost_curve::AbstractVector{Float64} = Float64[]
     om_cost_per_kwh::Float64 = NaN
-    electric_efficiency_half_load = NaN
     electric_efficiency_full_load::Float64 = NaN
+    electric_efficiency_half_load::Float64 = NaN
     min_turn_down_fraction::Float64 = NaN
     thermal_efficiency_full_load::Float64 = NaN
     thermal_efficiency_half_load::Float64 = NaN
@@ -118,9 +116,9 @@ Base.@kwdef mutable struct CHP <: AbstractCHP
     unavailability_periods::AbstractVector{Dict} = Dict[]
 
     # Optional inputs:
-    size_class::Int = 1
+    size_class::Union{Int, Nothing} = nothing
     min_kw::Float64 = 0.0
-    fuel_type::String = "natural_gas" # "restrict_to": ["natural_gas", "landfill_bio_gas", "propane", "diesel_oil"]
+    fuel_type::String = "natural_gas"
     om_cost_per_kw::Float64 = 0.0
     om_cost_per_hr_per_kw_rated::Float64 = 0.0
     supplementary_firing_capital_cost_per_kw::Float64 = 150.0
@@ -128,7 +126,7 @@ Base.@kwdef mutable struct CHP <: AbstractCHP
     supplementary_firing_efficiency::Float64 = 0.92
     standby_rate_per_kw_per_month::Float64 = 0.0
     reduces_demand_charges::Bool = true
-    can_supply_steam_turbine::Bool=false
+    can_supply_steam_turbine::Bool = false
 
     macrs_option_years::Int = 5
     macrs_bonus_fraction::Float64 = 1.0
@@ -159,7 +157,21 @@ Base.@kwdef mutable struct CHP <: AbstractCHP
 end
 
 
-function CHP(d::Dict)
+function CHP(d::Dict; 
+            avg_boiler_fuel_load_mmbtu_per_hour::Union{Float64, Nothing}=nothing, 
+            existing_boiler::Union{ExistingBoiler, Nothing}=nothing)
+    # If array inputs are coming from Julia JSON.parsefile (reader), they have type Vector{Any}; convert to expected type here
+    for (k,v) in d
+        if typeof(v) <: AbstractVector{Any} && k != "unavailability_periods"
+            d[k] = convert(Vector{Float64}, v)
+        end
+    end
+
+    # Check for required fuel cost
+    if !haskey(d, "fuel_cost_per_mmbtu")
+        @error "CHP must have the required fuel_cost_per_mmbtu input"
+    end
+    # Create CHP struct from inputs, to be mutated as needed
     chp = CHP(; dictkeys_tosymbols(d)...)
 
     @assert chp.fuel_type in FUEL_TYPES
@@ -187,44 +199,32 @@ function CHP(d::Dict)
             chp.tech_sizes_for_cost_curve = []
             @warn "Ignoring `chp.tech_sizes_for_cost_curve` input because `chp.installed_cost_per_kw` is a scalar"
         end
-    elseif !isempty(chp.installed_cost_per_kw) && isempty(chp.tech_sizes_for_cost_curve)
+    elseif length(chp.installed_cost_per_kw) > 1 && length(chp.installed_cost_per_kw) != length(chp.tech_sizes_for_cost_curve)
         @error "To model CHP cost curve, you must provide `chp.tech_sizes_for_cost_curve` vector of equal length to `chp.installed_cost_per_kw`"
-    elseif isempty(chp.tech_sizes_for_cost_curve)
+    elseif isempty(chp.tech_sizes_for_cost_curve) && isempty(chp.installed_cost_per_kw)
         update_installed_cost_params = true
     elseif isempty(chp.prime_mover)
         pass_all_params_error = true
     end
 
-    if isempty(chp.prime_mover)
-        if !pass_all_params_error
-            if any(isnan(v) for v in values(custom_chp_inputs)) || isempty(chp.unavailability_periods)
-                pass_all_params_error = true
-            end
-        end
-        if pass_all_params_error
-            @error "To model CHP you must provide at least `prime_mover` from $(prime_movers) or all of $([string(k) for k in keys(custom_chp_inputs)]) and unavailability_periods."
-        end        
-    elseif !(isempty(chp.prime_mover))
-        @assert chp.prime_mover in prime_movers
-        if chp.prime_mover == "combustion_turbine"
-            boiler_type = "steam"
-        else
-            boiler_type = "hot_water"
-        end
-        # set all missing default values in custom_chp_inputs
-        defaults = get_prime_mover_defaults(chp.prime_mover, boiler_type, chp.size_class)
-        for (k, v) in custom_chp_inputs
-            if k in [:installed_cost_per_kw, :tech_sizes_for_cost_curve]
-                if update_installed_cost_params
-                    setproperty!(chp, k, defaults[string(k)])
-                end
-            elseif isnan(v)
+    # Set all missing default values in custom_chp_inputs
+    chp_defaults_response = get_chp_defaults_prime_mover_size_class(;hot_water_or_steam=existing_boiler.production_type,
+                                                                avg_boiler_fuel_load_mmbtu_per_hour=avg_boiler_fuel_load_mmbtu_per_hour,
+                                                                prime_mover=chp.prime_mover,
+                                                                size_class=chp.size_class,
+                                                                boiler_efficiency=existing_boiler.efficiency)
+    defaults = chp_defaults_response["default_inputs"]
+    for (k, v) in custom_chp_inputs
+        if k in [:installed_cost_per_kw, :tech_sizes_for_cost_curve]
+            if update_installed_cost_params
                 setproperty!(chp, k, defaults[string(k)])
             end
+        elseif isnan(v)
+            setproperty!(chp, k, defaults[string(k)])
         end
-        if isempty(chp.unavailability_periods)
-            chp.unavailability_periods = defaults["unavailability_periods"]
-        end
+    end
+    if isempty(chp.unavailability_periods)
+        chp.unavailability_periods = defaults["unavailability_periods"]
     end
 
     return chp
@@ -232,7 +232,7 @@ end
 
 
 """
-    get_prime_mover_defaults(prime_mover::String, boiler_type::String, size_class::Int)
+    get_prime_mover_defaults(prime_mover::String, boiler_type::String, size_class::Int, prime_mover_defaults_all::Dict)
 
 return a Dict{String, Union{Float64, AbstractVector{Float64}}} by selecting the appropriate values from 
 data/chp/chp_default_data.json, which contains values based on prime_mover, boiler_type, and size_class for the 
@@ -241,13 +241,14 @@ custom_chp_inputs, i.e.
 - "tech_sizes_for_cost_curve"
 - "om_cost_per_kwh"
 - "electric_efficiency_full_load"
+- "electric_efficiency_half_load"
 - "min_turn_down_fraction",
 - "thermal_efficiency_full_load"
 - "thermal_efficiency_half_load"
 - "unavailability_periods"
 """
-function get_prime_mover_defaults(prime_mover::String, boiler_type::String, size_class::Int)
-    pmds = JSON.parsefile(joinpath(dirname(@__FILE__), "..", "..", "data", "chp", "chp_defaults.json"))
+function get_prime_mover_defaults(prime_mover::String, boiler_type::String, size_class::Int, prime_mover_defaults_all::Dict)
+    pmds = prime_mover_defaults_all
     prime_mover_defaults = Dict{String, Any}()
 
     for key in keys(pmds[prime_mover])
@@ -267,4 +268,141 @@ function get_prime_mover_defaults(prime_mover::String, boiler_type::String, size
         end
     end
     return prime_mover_defaults
+end
+
+
+"""
+    get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{String, Nothing}=nothing,
+                                        avg_boiler_fuel_load_mmbtu_per_hour::Union{Float64, Vector{Float64}, Nothing}=nothing,
+                                        prime_mover::Union{String, Nothing}=nothing,
+                                        size_class::Union{Int64, Nothing}=nothing,
+                                        boiler_efficiency::Union{Float64, Nothing}=nothing)
+
+Depending on the set of inputs, different sets of outputs are determine in addition to all CHP cost and performance parameter defaults:
+    1. Inputs: existing_boiler_production_type_steam_or_hw and avg_boiler_fuel_load_mmbtu_per_hour
+       Outputs: prime_mover, size_class, chp_size_based_on_avg_heating_load_kw
+    2. Inputs: prime_mover and avg_boiler_fuel_load_mmbtu_per_hour
+       Outputs: size_class
+    3. Inputs: prime_mover and size_class
+       Outputs: (uses default hot_water_or_steam)
+    4. Inputs: prime_mover
+       Outputs: default average size_class = 1
+
+The main purpose of this function is to communicate the following mapping of dependency of CHP defaults versus 
+    existing_boiler_production_type_steam_or_hot_water and avg_boiler_fuel_load_mmbtu_per_hour:
+If hot_water and <= 27 MMBtu/hr avg_boiler_fuel_load_mmbtu_per_hour --> prime_mover = recip_engine of size_class X
+If hot_water and > 27 MMBtu/hr avg_boiler_fuel_load_mmbtu_per_hour --> prime_mover = combustion_turbine of size_class X
+If steam and <= 7 MMBtu/hr avg_boiler_fuel_load_mmbtu_per_hour --> prime_mover = recip_engine of size_class X
+If steam and > 7 MMBtu/hr avg_boiler_fuel_load_mmbtu_per_hour --> prime_mover = combustion_turbine of size_class X
+
+The threshold avg_boiler_fuel_load_mmbtu_per_hour are based on industry expert judgements for applicable prime_movers where
+reciprocating engine is more suitable for smaller sizes and hot water, and combustion turbine is more suitable
+for larger sizes and steam.
+"""
+function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{String, Nothing}=nothing,
+                                                avg_boiler_fuel_load_mmbtu_per_hour::Union{Float64, Vector{Float64}, Nothing}=nothing,
+                                                prime_mover::Union{String, Nothing}=nothing,
+                                                size_class::Union{Int64, Nothing}=nothing,
+                                                boiler_efficiency::Union{Float64, Nothing}=nothing)
+    
+    prime_mover_defaults_all = JSON.parsefile(joinpath(@__DIR__, "..", "..", "data", "chp", "chp_defaults.json"))
+    avg_boiler_fuel_load_under_recip_over_ct = Dict([("hot_water", 27.0), ("steam", 7.0)])  # [MMBtu/hr] Based on external calcs for size versus production by prime_mover type
+
+    # Inputs validation
+    if !isnothing(prime_mover)
+        if !(prime_mover in prime_movers)  # Validate user-entered hot_water_or_steam
+            @error "Invalid argument for hot_water_or_steam; must be 'hot_water' or 'steam'"
+        end
+    end
+
+    if !isnothing(hot_water_or_steam)  # Option 1 if prime_mover also not input
+        if !(hot_water_or_steam in ["hot_water", "steam"])  # Validate user-entered hot_water_or_steam
+            @error "Invalid argument for hot_water_or_steam; must be 'hot_water' or 'steam'"
+        end
+    else  # Options 2, 3, or 4
+        hot_water_or_steam = "hot_water"
+    end
+
+    if !isnothing(avg_boiler_fuel_load_mmbtu_per_hour)  # Option 1
+        if avg_boiler_fuel_load_mmbtu_per_hour <= 0
+            @error "avg_boiler_fuel_load_mmbtu_per_hour must be >= 0.0"
+        end
+    end
+
+    # Calculate heuristic CHP size based on average thermal load, using the default size class efficiency data
+    if !isnothing(avg_boiler_fuel_load_mmbtu_per_hour)
+        if isnothing(prime_mover)
+            if avg_boiler_fuel_load_mmbtu_per_hour <= avg_boiler_fuel_load_under_recip_over_ct[hot_water_or_steam]
+                prime_mover = "recip_engine"  # Must make an initial guess at prime_mover to use those thermal and electric efficiency params to convert to size
+            else
+                prime_mover = "combustion_turbine"
+            end
+        end
+        if isnothing(size_class)
+            size_class_calc = 1
+        else
+            size_class_calc = size_class
+        end
+        if isnothing(boiler_efficiency)
+            boiler_effic = existing_boiler_efficiency_defaults[hot_water_or_steam]
+        else
+            boiler_effic = boiler_efficiency
+        end
+        therm_effic = prime_mover_defaults_all[prime_mover]["thermal_efficiency_full_load"][hot_water_or_steam][size_class_calc]
+        elec_effic = prime_mover_defaults_all[prime_mover]["electric_efficiency_full_load"][size_class_calc]
+        avg_heating_thermal_load_mmbtu_per_hr = avg_boiler_fuel_load_mmbtu_per_hour * boiler_effic
+        chp_fuel_rate_mmbtu_per_hr = avg_heating_thermal_load_mmbtu_per_hr / therm_effic
+        chp_elec_size_heuristic_kw = chp_fuel_rate_mmbtu_per_hr * elec_effic * KWH_PER_MMBTU
+    else
+        chp_elec_size_heuristic_kw = nothing
+    end
+
+    # Assign recip_engine as the (default) prime mover if not input or assigned base on avg_boiler_fuel_load_mmbtu_per_hour
+    if isnothing(prime_mover)
+        prime_mover = "recip_engine"
+    end
+
+    # prime_mover now assigned even if it was not input, so now load in these size_class metrics
+    n_classes = length(prime_mover_defaults_all[prime_mover]["installed_cost_per_kw"])
+    class_bounds = prime_mover_defaults_all[prime_mover]["tech_sizes_for_cost_curve"]
+
+    # If size class is specified use that and ignore heuristic CHP sizing for determining size class
+    if !isnothing(size_class)
+        if size_class < 1 || size_class >= n_classes
+            @error "The size class input is outside the valid range of 1-$n_classes for prime_mover $prime_mover"
+        end
+    # If size class is not specified, heuristic sizing based on avg thermal load and size class 0 efficiencies
+    elseif isnothing(size_class) && !isnothing(chp_elec_size_heuristic_kw)
+        # With heuristic size, find the suggested size class
+        if chp_elec_size_heuristic_kw < class_bounds[2][2]
+            # If smaller than the upper bound of the smallest class, assign the smallest class
+            size_class = 2
+        elseif chp_elec_size_heuristic_kw >= class_bounds[n_classes][1]
+            # If larger than or equal to the lower bound of the largest class, assign the largest class
+            size_class = n_classes # Size classes are one-indexed
+        else
+            # For middle size classes
+            for sc in 2:(n_classes-1)
+                if chp_elec_size_heuristic_kw >= class_bounds[sc][1] && 
+                    chp_elec_size_heuristic_kw < class_bounds[sc][2]
+                    size_class = sc
+                end
+            end
+        end
+    else
+        size_class = 1
+    end
+
+    prime_mover_defaults = get_prime_mover_defaults(prime_mover, hot_water_or_steam, size_class, prime_mover_defaults_all)
+
+    response = Dict([
+        ("prime_mover", prime_mover),
+        ("size_class", size_class),
+        ("hot_water_or_steam", hot_water_or_steam),
+        ("default_inputs", prime_mover_defaults),
+        ("chp_size_based_on_avg_heating_load_kw", chp_elec_size_heuristic_kw),
+        ("size_class_bounds", class_bounds)
+    ])
+    return response
+
 end

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -329,6 +329,13 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
         end
     end
 
+    if !isnothing(size_class) && !isnothing(prime_mover) # Option 3
+        n_classes = length(prime_mover_defaults_all[prime_mover]["installed_cost_per_kw"])
+        if size_class < 1 || size_class >= n_classes
+            @error "The size class input is outside the valid range of 1-$n_classes for prime_mover $prime_mover"
+        end
+    end
+
     # Calculate heuristic CHP size based on average thermal load, using the default size class efficiency data
     if !isnothing(avg_boiler_fuel_load_mmbtu_per_hour)
         if isnothing(prime_mover)

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -207,12 +207,20 @@ function CHP(d::Dict;
         pass_all_params_error = true
     end
 
-    # Set all missing default values in custom_chp_inputs
-    chp_defaults_response = get_chp_defaults_prime_mover_size_class(;hot_water_or_steam=existing_boiler.production_type,
+    # Set all missing default values in custom_chp_inputs after checking for an existing boiler; this allows CHP wo/ existing boiler
+    if !isnothing(existing_boiler)
+        prod_type = existing_boiler.production_type
+        eff = existing_boiler.efficiency
+    else
+        prod_type = "hot_water"
+        eff = EXISTING_BOILER_EFFICIENCY
+    end
+
+    chp_defaults_response = get_chp_defaults_prime_mover_size_class(;hot_water_or_steam=prod_type,
                                                                 avg_boiler_fuel_load_mmbtu_per_hour=avg_boiler_fuel_load_mmbtu_per_hour,
                                                                 prime_mover=chp.prime_mover,
                                                                 size_class=chp.size_class,
-                                                                boiler_efficiency=existing_boiler.efficiency)
+                                                                boiler_efficiency=eff)
     defaults = chp_defaults_response["default_inputs"]
     for (k, v) in custom_chp_inputs
         if k in [:installed_cost_per_kw, :tech_sizes_for_cost_curve]

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -311,13 +311,13 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
     # Inputs validation
     if !isnothing(prime_mover)
         if !(prime_mover in prime_movers)  # Validate user-entered hot_water_or_steam
-            @error "Invalid argument for hot_water_or_steam; must be 'hot_water' or 'steam'"
+            @error "Invalid argument for `prime_mover`; must be in $prime_movers"
         end
     end
 
     if !isnothing(hot_water_or_steam)  # Option 1 if prime_mover also not input
         if !(hot_water_or_steam in ["hot_water", "steam"])  # Validate user-entered hot_water_or_steam
-            @error "Invalid argument for hot_water_or_steam; must be 'hot_water' or 'steam'"
+            @error "Invalid argument for `hot_water_or_steam``; must be `hot_water` or `steam`"
         end
     else  # Options 2, 3, or 4
         hot_water_or_steam = "hot_water"

--- a/src/core/doe_commercial_reference_building_loads.jl
+++ b/src/core/doe_commercial_reference_building_loads.jl
@@ -54,7 +54,7 @@ const default_buildings = [
 
 
 function find_ashrae_zone_city(lat, lon; get_zone=false)
-    file_path = joinpath(dirname(@__FILE__), "..", "..", "data", "climate_cities.shp")
+    file_path = joinpath(@__DIR__, "..", "..", "data", "climate_cities.shp")
     shpfile = ArchGDAL.read(file_path)
 	cities_layer = ArchGDAL.getlayer(shpfile, 0)
 
@@ -134,7 +134,7 @@ function built_in_load(type::String, city::String, buildingtype::String,
 
     @assert type in ["electric", "domestic_hot_water", "space_heating", "cooling"]
     monthly_scalers = ones(12)
-    lib_path = joinpath(dirname(@__FILE__), "..", "..", "data", "load_profiles", type)
+    lib_path = joinpath(@__DIR__, "..", "..", "data", "load_profiles", type)
 
     profile_path = joinpath(lib_path, string("crb8760_norm_" * city * "_" * buildingtype * ".dat"))
     if occursin("FlatLoad", buildingtype)

--- a/src/core/production_factor.jl
+++ b/src/core/production_factor.jl
@@ -196,7 +196,7 @@ function get_production_factor(wind::Wind, latitude::Real, longitude::Real, time
                       You can alternatively provide the Wind.production_factor_series"""
         end
 
-        global hdl = joinpath(dirname(@__FILE__), "..", "sam", libfile)
+        global hdl = joinpath(@__DIR__, "..", "sam", libfile)
         wind_module = @ccall hdl.ssc_module_create("windpower"::Cstring)::Ptr{Cvoid}
         wind_resource = @ccall hdl.ssc_data_create()::Ptr{Cvoid}  # data pointer
         @ccall hdl.ssc_module_exec_set_print(0::Cint)::Cvoid

--- a/src/results/chp.jl
+++ b/src/results/chp.jl
@@ -29,21 +29,23 @@
 # *********************************************************************************
 """
 `CHP` results keys:
-- `size_kw`  # Power capacity size of the CHP system [kW]
-- `size_supplemental_firing_kw`  # Power capacity of CHP supplementary firing system [kW]
-- `year_one_fuel_used_mmbtu`  # Fuel consumed in year one [MMBtu]
-- `year_one_electric_energy_produced_kwh`  # Electric energy produced in year one [kWh]
-- `year_one_thermal_energy_produced_mmbtu`  # Thermal energy produced in year one [MMBtu]
-- `year_one_electric_production_series_kw`  # Electric power production time-series array [kW]
-- `year_one_to_grid_series_kw`  # Electric power exported time-series array [kW]
-- `year_one_to_battery_series_kw`  # Electric power to charge the battery storage time-series array [kW]
-- `year_one_to_load_series_kw`  # Electric power to serve the electric load time-series array [kW]
-- `year_one_thermal_to_tes_series_mmbtu_per_hour`  # Thermal power to TES time-series array [MMBtu/hr]
-- `year_one_thermal_to_waste_series_mmbtu_per_hour`  # Thermal power wasted/unused/vented time-series array [MMBtu/hr]
-- `year_one_thermal_to_load_series_mmbtu_per_hour`  # Thermal power to serve the heating load time-series array [MMBtu/hr]
-- `year_one_chp_fuel_cost_before_tax`  # Fuel cost from fuel consumed by the CHP system [\$]
-- `lifecycle_chp_fuel_cost_after_tax`  # Fuel cost from fuel consumed by the CHP system, after tax [\$]
-- `year_one_chp_standby_cost_before_tax`  # CHP standby charges in year one [\$] 
+- `size_kw` Power capacity size of the CHP system [kW]
+- `size_supplemental_firing_kw` Power capacity of CHP supplementary firing system [kW]
+- `year_one_fuel_used_mmbtu` Fuel consumed in year one [MMBtu]
+- `year_one_electric_energy_produced_kwh` Electric energy produced in year one [kWh]
+- `year_one_thermal_energy_produced_mmbtu` Thermal energy produced in year one [MMBtu]
+- `year_one_electric_production_series_kw` Electric power production time-series array [kW]
+- `year_one_to_grid_series_kw` Electric power exported time-series array [kW]
+- `year_one_to_battery_series_kw` Electric power to charge the battery storage time-series array [kW]
+- `year_one_to_load_series_kw` Electric power to serve the electric load time-series array [kW]
+- `year_one_thermal_to_tes_series_mmbtu_per_hour` Thermal power to TES time-series array [MMBtu/hr]
+- `year_one_thermal_to_waste_series_mmbtu_per_hour` Thermal power wasted/unused/vented time-series array [MMBtu/hr]
+- `year_one_thermal_to_load_series_mmbtu_per_hour` Thermal power to serve the heating load time-series array [MMBtu/hr]
+- `year_one_thermal_to_steamturbine_series_mmbtu_per_hour` Thermal (steam) power to steam turbine time-series array [MMBtu/hr]
+- `year_one_chp_fuel_cost_before_tax` Cost of fuel consumed by the CHP system in year one [\$]
+- `lifecycle_chp_fuel_cost_after_tax` Present value of cost of fuel consumed by the CHP system, after tax [\$]
+- `year_one_chp_standby_cost_before_tax` CHP standby charges in year one [\$] 
+- `lifecycle_chp_standby_cost_after_tax` Present value of all CHP standby charges, after tax.
 """
 function add_chp_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
 	# Adds the `CHP` results to the dictionary passed back from `run_reopt` using the solved model `m` and the `REoptInputs` for node `_n`.

--- a/src/results/heating_cooling_load.jl
+++ b/src/results/heating_cooling_load.jl
@@ -73,12 +73,19 @@ function add_heating_load_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict
     dhw_load_series_kw = p.s.dhw_load.loads_kw
     space_heating_load_series_kw = p.s.space_heating_load.loads_kw
 
+    existing_boiler_efficiency = nothing
+    if isnothing(p.s.existing_boiler)
+        existing_boiler_efficiency = EXISTING_BOILER_EFFICIENCY
+    else
+        existing_boiler_efficiency = p.s.existing_boiler.efficiency
+    end
+    
     r["dhw_thermal_load_series_mmbtu_per_hour"] = dhw_load_series_kw ./ KWH_PER_MMBTU
     r["space_heating_thermal_load_series_mmbtu_per_hour"] = space_heating_load_series_kw ./ KWH_PER_MMBTU
     r["total_heating_thermal_load_series_mmbtu_per_hour"] = r["dhw_thermal_load_series_mmbtu_per_hour"] .+ r["space_heating_thermal_load_series_mmbtu_per_hour"]
 
-    r["dhw_boiler_fuel_load_series_mmbtu_per_hour"] = dhw_load_series_kw ./ KWH_PER_MMBTU ./ p.s.existing_boiler.efficiency
-    r["space_heating_boiler_fuel_load_series_mmbtu_per_hour"] = space_heating_load_series_kw ./ KWH_PER_MMBTU ./ p.s.existing_boiler.efficiency
+    r["dhw_boiler_fuel_load_series_mmbtu_per_hour"] = dhw_load_series_kw ./ KWH_PER_MMBTU ./ existing_boiler_efficiency
+    r["space_heating_boiler_fuel_load_series_mmbtu_per_hour"] = space_heating_load_series_kw ./ KWH_PER_MMBTU ./ existing_boiler_efficiency
     r["total_heating_boiler_fuel_load_series_mmbtu_per_hour"] = r["dhw_boiler_fuel_load_series_mmbtu_per_hour"] .+ r["space_heating_boiler_fuel_load_series_mmbtu_per_hour"]
 
     r["annual_calculated_dhw_thermal_load_mmbtu"] = round(
@@ -89,9 +96,9 @@ function add_heating_load_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict
     )
     r["annual_calculated_total_heating_thermal_load_mmbtu"] = r["annual_calculated_dhw_thermal_load_mmbtu"] + r["annual_calculated_space_heating_thermal_load_mmbtu"]
     
-    r["annual_calculated_dhw_boiler_fuel_load_mmbtu"] = r["annual_calculated_dhw_thermal_load_mmbtu"] / p.s.existing_boiler.efficiency
-    r["annual_calculated_space_heating_boiler_fuel_load_mmbtu"] = r["annual_calculated_space_heating_thermal_load_mmbtu"] / p.s.existing_boiler.efficiency
-    r["annual_calculated_total_heating_boiler_fuel_load_mmbtu"] = r["annual_calculated_total_heating_thermal_load_mmbtu"] / p.s.existing_boiler.efficiency
+    r["annual_calculated_dhw_boiler_fuel_load_mmbtu"] = r["annual_calculated_dhw_thermal_load_mmbtu"] / existing_boiler_efficiency
+    r["annual_calculated_space_heating_boiler_fuel_load_mmbtu"] = r["annual_calculated_space_heating_thermal_load_mmbtu"] / existing_boiler_efficiency
+    r["annual_calculated_total_heating_boiler_fuel_load_mmbtu"] = r["annual_calculated_total_heating_thermal_load_mmbtu"] / existing_boiler_efficiency
 
     d["HeatingLoad"] = r
     nothing

--- a/test/scenarios/heating_cooling_load_inputs.json
+++ b/test/scenarios/heating_cooling_load_inputs.json
@@ -32,5 +32,9 @@
     "Storage": {
         "max_kwh": 0,
         "max_kw": 0
-    }    
+    },
+    "CHP": {
+        "prime_mover": "recip_engine",
+        "fuel_cost_per_mmbtu": 10
+    }
 }


### PR DESCRIPTION
See https://github.com/NREL/REopt.jl/pull/142. 

**TODO**
Add test for expected CHP size_class and/or prime_mover based on average heating load and existing boiler production type.