### PR TITLE
ThermalStorage Update to Water Property with CoolProp and Round Size

### DIFF
--- a/src/core/energy_storage/thermal_storage.jl
+++ b/src/core/energy_storage/thermal_storage.jl
@@ -145,7 +145,6 @@ struct ThermalStorage <: AbstractThermalStorage
     function ThermalStorage(s::AbstractThermalStorageDefaults, f::Financial, time_steps_per_hour::Int)
          
         kwh_per_gal = get_kwh_per_gal(s.hot_water_temp_degF, s.cool_water_temp_degF)
-        println("kwh_per_gal = ", kwh_per_gal)
         min_kwh = s.min_gal * kwh_per_gal
         max_kwh = s.max_gal * kwh_per_gal
         min_kw = min_kwh * time_steps_per_hour

--- a/src/core/energy_storage/thermal_storage.jl
+++ b/src/core/energy_storage/thermal_storage.jl
@@ -145,8 +145,9 @@ struct ThermalStorage <: AbstractThermalStorage
     function ThermalStorage(s::AbstractThermalStorageDefaults, f::Financial, time_steps_per_hour::Int)
          
         delta_T_degF = s.hot_water_temp_degF - s.cool_water_temp_degF
-        avg_rho_kg_per_m3 = 998.2 
-        avg_cp_kj_per_kgK = 4.184 #TODO: add CoolProp reference or perform analogous calculations for water and build lookup tables
+        avg_T_degF = (s.hot_water_temp_degF + s.cool_water_temp_degF) / 2.0
+        avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")  # [kg/m^3]
+        avg_cp_kj_per_kgK = PropsSI("CPMASS","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")/1000  # kJ/kg-K
         kwh_per_gal = convert_gal_to_kwh(delta_T_degF, avg_rho_kg_per_m3, avg_cp_kj_per_kgK)
         min_kwh = s.min_gal * kwh_per_gal
         max_kwh = s.max_gal * kwh_per_gal

--- a/src/core/energy_storage/thermal_storage.jl
+++ b/src/core/energy_storage/thermal_storage.jl
@@ -144,11 +144,8 @@ struct ThermalStorage <: AbstractThermalStorage
 
     function ThermalStorage(s::AbstractThermalStorageDefaults, f::Financial, time_steps_per_hour::Int)
          
-        delta_T_degF = s.hot_water_temp_degF - s.cool_water_temp_degF
-        avg_T_degF = (s.hot_water_temp_degF + s.cool_water_temp_degF) / 2.0
-        avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")  # [kg/m^3]
-        avg_cp_kj_per_kgK = PropsSI("CPMASS","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")/1000  # kJ/kg-K
-        kwh_per_gal = convert_gal_to_kwh(delta_T_degF, avg_rho_kg_per_m3, avg_cp_kj_per_kgK)
+        kwh_per_gal = get_kwh_per_gal(s.hot_water_temp_degF, s.cool_water_temp_degF)
+        println("kwh_per_gal = ", kwh_per_gal)
         min_kwh = s.min_gal * kwh_per_gal
         max_kwh = s.max_gal * kwh_per_gal
         min_kw = min_kwh * time_steps_per_hour

--- a/src/core/steam_turbine.jl
+++ b/src/core/steam_turbine.jl
@@ -165,10 +165,10 @@ function assign_st_elec_and_therm_prod_ratios!(st::SteamTurbine)
     p_in_pa = (st.inlet_steam_pressure_psig / 14.5038 + 1.01325) * 1.0E5
     if isnan(st.inlet_steam_temperature_degF)
         t_in_sat_k = PropsSI("T","P",p_in_pa,"Q",1.0,"Water")
-        t_superheat_in_k = (st.inlet_steam_superheat_degF - 32.0) * 5.0 / 9.0 + 273.15
+        t_superheat_in_k = convert_temp_degF_to_Kelvin(st.inlet_steam_superheat_degF)
         t_in_k = t_in_sat_k + t_superheat_in_k
     else
-        t_in_k = (st.inlet_steam_temperature_degF - 32.0) * 5.0 / 9.0 + 273.15
+        t_in_k = convert_temp_degF_to_Kelvin(st.inlet_steam_temperature_degF)
     end
     h_in_j_per_kg = PropsSI("H","P",p_in_pa,"T",t_in_k,"Water")
     s_in_j_per_kgK = PropsSI("S","P",p_in_pa,"T",t_in_k,"Water")

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -434,3 +434,7 @@ end
 macro argname(arg)
     string(arg)
 end
+
+function convert_temp_degF_to_Kelvin(degF::Float64)
+    return (degF - 32) * 5.0 / 9.0 + 273.15
+end

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -404,6 +404,8 @@ end
 
 """
     Convert gallons of stored liquid (e.g. water, water/glycol) to kWh of stored energy in a stratefied tank
+    Note: uses the PropsSI function from the CoolProp package.  Further details on inputs used are available
+        at: http://www.coolprop.org/coolprop/HighLevelAPI.html
     :param delta_T_degF: temperature difference between the hot/warm side and the cold side
     :param rho_kg_per_m3: density of the liquid
     :param cp_kj_per_kgK: heat capacity of the liquid

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -409,9 +409,13 @@ end
     :param cp_kj_per_kgK: heat capacity of the liquid
     :return gal_to_kwh: stored energy, in kWh
 """
-function convert_gal_to_kwh(delta_T_degF::Real, rho_kg_per_m3::Real, cp_kj_per_kgK::Real)
-    delta_T_K = delta_T_degF * 5.0 / 9.0  # [K]
-    kj_per_m3 = rho_kg_per_m3 * cp_kj_per_kgK * delta_T_K  # [kJ/m^3]
+function get_kwh_per_gal(t_hot_degF::Real, t_cold_degF::Real, fluid::String="Water")
+    t_hot_K = convert_temp_degF_to_Kelvin(t_hot_degF)  # [K]
+    t_cold_K = convert_temp_degF_to_Kelvin(t_cold_degF)  # [K]
+    avg_t_K = (t_hot_K + t_cold_K) / 2.0
+    avg_rho_kg_per_m3 = PropsSI("D", "P", 101325.0, "T", avg_t_K, fluid)  # [kg/m^3]
+    avg_cp_kj_per_kgK = PropsSI("CPMASS", "P", 101325.0, "T", avg_t_K, fluid) / 1000  # kJ/kg-K
+    kj_per_m3 = avg_rho_kg_per_m3 * avg_cp_kj_per_kgK * (t_hot_K - t_cold_K)  # [kJ/m^3]
     kj_per_gal = kj_per_m3 / 264.172   # divide by gal/m^3 to get: [kJ/gal]
     kwh_per_gal = kj_per_gal / 3600.0  # divide by kJ/kWh, i.e., sec/hr, to get: [kWh/gal]
     return kwh_per_gal

--- a/src/results/thermal_storage.jl
+++ b/src/results/thermal_storage.jl
@@ -37,11 +37,8 @@ function add_hot_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict,
     # Adds the `HotThermalStorage` results to the dictionary passed back from `run_reopt` using the solved model `m` and the `REoptInputs` for node `_n`.
     # Note: the node number is an empty string if evaluating a single `Site`.
 
-    delta_T_degF = p.s.storage.attr["HotThermalStorage"].hot_water_temp_degF - p.s.storage.attr["HotThermalStorage"].cool_water_temp_degF
-    avg_T_degF = (p.s.storage.attr["HotThermalStorage"].hot_water_temp_degF + p.s.storage.attr["HotThermalStorage"].cool_water_temp_degF) / 2.0
-    avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")  # [kg/m^3]
-    avg_cp_kj_per_kgK = PropsSI("CPMASS","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")/1000  # kJ/kg-K
-    kwh_per_gal = convert_gal_to_kwh(delta_T_degF, avg_rho_kg_per_m3, avg_cp_kj_per_kgK)
+    kwh_per_gal = get_kwh_per_gal(p.s.storage.attr["HotThermalStorage"].hot_water_temp_degF,
+                                    p.s.storage.attr["HotThermalStorage"].cool_water_temp_degF)
     
     r = Dict{String, Any}()
     size_kwh = round(value(m[Symbol("dvStorageEnergy"*_n)][b]), digits=3)
@@ -92,11 +89,8 @@ function add_cold_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict
     Note: the node number is an empty string if evaluating a single `Site`.
     =#
 
-    delta_T_degF = p.s.storage.attr["ColdThermalStorage"].hot_water_temp_degF - p.s.storage.attr["ColdThermalStorage"].cool_water_temp_degF
-    avg_T_degF = (p.s.storage.attr["ColdThermalStorage"].hot_water_temp_degF + p.s.storage.attr["ColdThermalStorage"].cool_water_temp_degF) / 2.0
-    avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")  # [kg/m^3]
-    avg_cp_kj_per_kgK = PropsSI("CPMASS","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")/1000  # kJ/kg-K
-    kwh_per_gal = convert_gal_to_kwh(delta_T_degF, avg_rho_kg_per_m3, avg_cp_kj_per_kgK)
+    kwh_per_gal = get_kwh_per_gal(p.s.storage.attr["ColdThermalStorage"].hot_water_temp_degF,
+                                    p.s.storage.attr["ColdThermalStorage"].cool_water_temp_degF)
     
     r = Dict{String, Any}()
     size_kwh = round(value(m[Symbol("dvStorageEnergy"*_n)][b]), digits=3)

--- a/src/results/thermal_storage.jl
+++ b/src/results/thermal_storage.jl
@@ -39,7 +39,7 @@ function add_hot_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict,
 
     delta_T_degF = p.s.storage.attr["HotThermalStorage"].hot_water_temp_degF - p.s.storage.attr["HotThermalStorage"].cool_water_temp_degF
     avg_T_degF = (p.s.storage.attr["HotThermalStorage"].hot_water_temp_degF + p.s.storage.attr["HotThermalStorage"].cool_water_temp_degF) / 2.0
-    avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")
+    avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")  # [kg/m^3]
     avg_cp_kj_per_kgK = PropsSI("CPMASS","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")/1000  # kJ/kg-K
     kwh_per_gal = convert_gal_to_kwh(delta_T_degF, avg_rho_kg_per_m3, avg_cp_kj_per_kgK)
     
@@ -94,7 +94,7 @@ function add_cold_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict
 
     delta_T_degF = p.s.storage.attr["ColdThermalStorage"].hot_water_temp_degF - p.s.storage.attr["ColdThermalStorage"].cool_water_temp_degF
     avg_T_degF = (p.s.storage.attr["ColdThermalStorage"].hot_water_temp_degF + p.s.storage.attr["ColdThermalStorage"].cool_water_temp_degF) / 2.0
-    avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")
+    avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")  # [kg/m^3]
     avg_cp_kj_per_kgK = PropsSI("CPMASS","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")/1000  # kJ/kg-K
     kwh_per_gal = convert_gal_to_kwh(delta_T_degF, avg_rho_kg_per_m3, avg_cp_kj_per_kgK)
     

--- a/src/results/thermal_storage.jl
+++ b/src/results/thermal_storage.jl
@@ -38,13 +38,14 @@ function add_hot_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict,
     # Note: the node number is an empty string if evaluating a single `Site`.
 
     delta_T_degF = p.s.storage.attr["HotThermalStorage"].hot_water_temp_degF - p.s.storage.attr["HotThermalStorage"].cool_water_temp_degF
-    avg_cp_kj_per_kgK = 998.2 
-    avg_rho_kg_per_m3 = 4.184 #TODO: add CoolProp reference or perform analogous calculations for water and build lookup tables
+    avg_T_degF = (p.s.storage.attr["HotThermalStorage"].hot_water_temp_degF + p.s.storage.attr["HotThermalStorage"].cool_water_temp_degF) / 2.0
+    avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")
+    avg_cp_kj_per_kgK = PropsSI("CPMASS","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")/1000  # kJ/kg-K
     kwh_per_gal = convert_gal_to_kwh(delta_T_degF, avg_rho_kg_per_m3, avg_cp_kj_per_kgK)
     
     r = Dict{String, Any}()
-    size_kwh = round(value(m[Symbol("dvStorageEnergy"*_n)][b]), digits=2)
-    r["size_gal"] = size_kwh / kwh_per_gal
+    size_kwh = round(value(m[Symbol("dvStorageEnergy"*_n)][b]), digits=3)
+    r["size_gal"] = round(size_kwh / kwh_per_gal, digits=0)
 
     if size_kwh != 0
     	soc = (m[Symbol("dvStoredEnergy"*_n)][b, ts] for ts in p.time_steps)
@@ -92,13 +93,14 @@ function add_cold_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict
     =#
 
     delta_T_degF = p.s.storage.attr["ColdThermalStorage"].hot_water_temp_degF - p.s.storage.attr["ColdThermalStorage"].cool_water_temp_degF
-    avg_cp_kj_per_kgK = 998.2 
-    avg_rho_kg_per_m3 = 4.184 #TODO: add CoolProp reference or perform analogous calculations for water and build lookup tables
+    avg_T_degF = (p.s.storage.attr["ColdThermalStorage"].hot_water_temp_degF + p.s.storage.attr["ColdThermalStorage"].cool_water_temp_degF) / 2.0
+    avg_rho_kg_per_m3 = PropsSI("D","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")
+    avg_cp_kj_per_kgK = PropsSI("CPMASS","P",101325,"T",convert_temp_degF_to_Kelvin(avg_T_degF),"Water")/1000  # kJ/kg-K
     kwh_per_gal = convert_gal_to_kwh(delta_T_degF, avg_rho_kg_per_m3, avg_cp_kj_per_kgK)
     
     r = Dict{String, Any}()
-    size_kwh = round(value(m[Symbol("dvStorageEnergy"*_n)][b]), digits=2)
-    r["size_gal"] = size_kwh / kwh_per_gal
+    size_kwh = round(value(m[Symbol("dvStorageEnergy"*_n)][b]), digits=3)
+    r["size_gal"] = round(size_kwh / kwh_per_gal, digits=0)
 
     if size_kwh != 0
     	soc = (m[Symbol("dvStoredEnergy"*_n)][b, ts] for ts in p.time_steps)

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -736,8 +736,8 @@ end
     @test sum(r["HotThermalStorage"]["year_one_to_load_series_mmbtu_per_hour"]) ≈ 149.45 atol=0.1
     @test sum(r["ColdThermalStorage"]["year_one_to_load_series_ton"]) ≈ 12454.33 atol=0.1
     #size should be just over 10kW in gallons, accounting for efficiency losses and min SOC
-    @test r["HotThermalStorage"]["size_gal"] ≈ 227.89 atol=0.1
-    @test r["ColdThermalStorage"]["size_gal"] ≈ 379.82 atol=0.1
+    @test r["HotThermalStorage"]["size_gal"] ≈ 233.0 atol=0.1
+    @test r["ColdThermalStorage"]["size_gal"] ≈ 378.0 atol=0.1
     #No production from existing chiller, only absorption chiller, which is sized at ~5kW to manage electric demand charge & capital cost.
     @test r["ExistingChiller"]["year_one_thermal_production_tonhour"] ≈ 0.0 atol=0.1
     @test r["AbsorptionChiller"]["year_one_thermal_production_tonhour"] ≈ 12464.15 atol=0.1


### PR DESCRIPTION
This PR:

1. Updates the water properties for converting the Hot/Cold ThermalStorage size in kWh thermal to gallons of storage to use CoolProp instead of an assumed static value. The CoolProp water property calls use the average water temperature input (or default) and an assumed water pressure (atmospheric) - liquid water properties are much stronger function of temperature than pressure.
2. Rounds the `ThermalStorage.size_gal` to 0 digits instead of many.
3. Add standard function for converting temperature in degrees Fahrenheit to Kelvin.