### PR TITLE
Fix proforma metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Classify the change according to the following categories:
 - Round Hot and Cold TES size result to 0 digits
 - Use CoolProp to get water properties for Hot and Cold TES based on average of temperature inputs
 ### Fixed
+- `Wind` evaluations with BAU - was temporarily broken because of an unconverted `year_one` -> `annual` expected name
 - Fixed calculation of `year_one_coincident_peak_cost_before_tax` in **ElectricTariff** results to correctly calculate before-tax value. Previously, the after-tax value was being calculated for this field instead.
 - Fixed `outage_simulator` to work with sub-hourly outage simulation scenarios
 - Fixed a bug which threw an error when providing time-series thermal load inputs in a scenario inputs .json.

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -313,7 +313,7 @@ function calculate_lcoe(p::REoptInputs, tech_results::Dict, tech::AbstractTech)
 
     #calculate the value of the production-based incentive stream
     npv_pbi = 0
-    year_one_energy_produced = :year_one_energy_produced_kwh in fieldnames(typeof(tech)) ? tech_results["year_one_energy_produced_kwh"] : tech_results["annual_energy_produced_kwh"]
+    year_one_energy_produced = "year_one_energy_produced_kwh" in keys(tech_results) ? tech_results["year_one_energy_produced_kwh"] : tech_results["annual_energy_produced_kwh"]
     degradation_fraction = :degradation_fraction in fieldnames(typeof(tech)) ? tech.degradation_fraction : 0.0
     if tech.production_incentive_max_benefit > 0
         for yr in 1:years

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -313,7 +313,7 @@ function calculate_lcoe(p::REoptInputs, tech_results::Dict, tech::AbstractTech)
 
     #calculate the value of the production-based incentive stream
     npv_pbi = 0
-    year_one_energy_produced = get(tech_results, "year_one_energy_produced_kwh", 0)
+    year_one_energy_produced = :year_one_energy_produced_kwh in fieldnames(typeof(tech)) ? tech_results["year_one_energy_produced_kwh"] : tech_results["annual_energy_produced_kwh"]
     degradation_fraction = :degradation_fraction in fieldnames(typeof(tech)) ? tech.degradation_fraction : 0.0
     if tech.production_incentive_max_benefit > 0
         for yr in 1:years

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -334,7 +334,7 @@ function update_metrics(m::Metrics, p::REoptInputs, tech::AbstractTech, tech_nam
     pbi_series = Float64[]
     pbi_series_bau = Float64[]
     existing_energy_bau = third_party ? get(results[tech_name], "year_one_energy_produced_kwh_bau", 0) : 0
-    year_one_energy = :year_one_energy_produced_kwh in fieldnames(typeof(tech)) ? results[tech_name]["year_one_energy_produced_kwh"] : results[tech_name]["annual_energy_produced_kwh"]
+    year_one_energy = "year_one_energy_produced_kwh" in keys(results[tech_name]) ? results[tech_name]["year_one_energy_produced_kwh"] : results[tech_name]["annual_energy_produced_kwh"]
     for yr in range(0, stop=years-1)
         if yr < tech.production_incentive_years
             degredation_fraction = :degradation_fraction in fieldnames(typeof(tech)) ? (1 - tech.degradation_fraction)^yr : 1.0

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -334,7 +334,7 @@ function update_metrics(m::Metrics, p::REoptInputs, tech::AbstractTech, tech_nam
     pbi_series = Float64[]
     pbi_series_bau = Float64[]
     existing_energy_bau = third_party ? get(results[tech_name], "year_one_energy_produced_kwh_bau", 0) : 0
-    year_one_energy = :year_one_energy_produced_kwh in fieldnames(typeof(tech)) ? tech_results["year_one_energy_produced_kwh"] : tech_results["annual_energy_produced_kwh"]
+    year_one_energy = :year_one_energy_produced_kwh in fieldnames(typeof(tech)) ? results[tech_name]["year_one_energy_produced_kwh"] : results[tech_name]["annual_energy_produced_kwh"]
     for yr in range(0, stop=years-1)
         if yr < tech.production_incentive_years
             degredation_fraction = :degradation_fraction in fieldnames(typeof(tech)) ? (1 - tech.degradation_fraction)^yr : 1.0

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -334,11 +334,12 @@ function update_metrics(m::Metrics, p::REoptInputs, tech::AbstractTech, tech_nam
     pbi_series = Float64[]
     pbi_series_bau = Float64[]
     existing_energy_bau = third_party ? get(results[tech_name], "year_one_energy_produced_kwh_bau", 0) : 0
+    year_one_energy = :year_one_energy_produced_kwh in fieldnames(typeof(tech)) ? tech_results["year_one_energy_produced_kwh"] : tech_results["annual_energy_produced_kwh"]
     for yr in range(0, stop=years-1)
         if yr < tech.production_incentive_years
             degredation_fraction = :degradation_fraction in fieldnames(typeof(tech)) ? (1 - tech.degradation_fraction)^yr : 1.0
             base_pbi = minimum([
-                tech.production_incentive_per_kwh * (results[tech_name]["year_one_energy_produced_kwh"] - existing_energy_bau) * degredation_fraction,  
+                tech.production_incentive_per_kwh * (year_one_energy - existing_energy_bau) * degredation_fraction,  
                 tech.production_incentive_max_benefit * degredation_fraction
             ])
             base_pbi_bau = minimum([


### PR DESCRIPTION
`Wind` analysis with BAU was broken because it was expecting `year_one_energy_produced_kwh` which no longer exists, for it's resulting LCOE calculation (only done with BAU, which the current Wind test does not have). This PR fixes this to use the `annual_energy_produced_kwh` for anything which does not have `year_one_energy_produced_kwh` and a `degradation_factor` (just `PV`).