### PR TITLE
Add CHP to stochastic/multi- outages, some CHP tweaks for UI V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Classify the change according to the following categories:
 - Iterate on calculating `CHP` heuristic size based on average heating load which is also used to set `max_kw` if not given: once `size_class` is determined, recalculate using the efficiency numbers for that `size_class`.
 ### Fixed
 - Fix non-handling of cost-curve/segmented techs in stochastic outages
+- Fix issues with `simulated_load.jl` monthly heating energy input to return the heating load profile
 
 ## v0.28.1
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,17 @@ Classify the change according to the following categories:
     ### Removed
 
 ## Develop 3/22/23
+### Added
+- Add `CHP` `FuelUsed` and `FuelCost` modeling/tracking for stochastic/multi-outages
+- Add `CHP` outputs for stochastic/multi-outages
 ### Changed
 - Made outages output names not dynamic to allow integration into API
 - Add missing units to outages results field names: **unserved_load_series_kw**, **unserved_load_per_outage_kwh**, **generator_fuel_used_per_outage_gal**
 - Default `Financial` field **microgrid_upgrade_cost_fraction** to 0
+- Add conditional logic to make `CHP.min_allowable_kw` 25% of `max_kw` if there is a conflicting relationship 
+- Iterate on calculating `CHP` heuristic size based on average heating load which is also used to set `max_kw` if not given: once `size_class` is determined, recalculate using the efficiency numbers for that `size_class`.
+### Fixed
+- Fix non-handling of cost-curve/segmented techs in stochastic outages
 
 ## v0.28.1
 ### Added

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -175,10 +175,10 @@ function add_MG_CHP_fuel_burn_constraints(m, p; _n="")
     if fuel_burn_intercept > 1.0E-7
         #Constraint (1c1): Total Fuel burn for CHP **with** y-intercept fuel burn and supplementary firing
         @constraint(m, MGCHPFuelBurnCon[t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps],
-            m[Symbol("dvMGFuelUsed"*_n)][t,s,tz]  == p.hours_per_time_step * 
+            m[Symbol("dvMGFuelUsed"*_n)][t,s,tz]  == p.hours_per_time_step * (
                 m[Symbol("dvMGCHPFuelBurnYIntercept"*_n)][s,tz] +
                 sum(p.production_factor[t,tz+ts-1] * fuel_burn_slope * m[Symbol("dvMGRatedProduction"*_n)][t,s,tz,ts]
-                    for ts in 1:p.s.electric_utility.outage_durations[s])
+                    for ts in 1:p.s.electric_utility.outage_durations[s]))
         )
 
         #Constraint (1d): Y-intercept fuel burn for CHP across the scenario outage time steps

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -161,7 +161,6 @@ function add_MG_Gen_fuel_burn_constraints(m,p)
         sum( m[:dvMGGenMaxFuelCost][s] * p.s.electric_utility.outage_probabilities[s] for s in p.s.electric_utility.scenarios )
     )
 
-    m[:ExpectedMGFuelUsed] += ExpectedMGGenFuelUsed
     m[:ExpectedMGFuelCost] += ExpectedMGGenFuelCost
 end
 
@@ -218,7 +217,6 @@ function add_MG_CHP_fuel_burn_constraints(m, p; _n="")
         sum( m[:dvMGCHPMaxFuelCost][s] * p.s.electric_utility.outage_probabilities[s] for s in p.s.electric_utility.scenarios )
     )
 
-    m[:ExpectedMGFuelUsed] += ExpectedMGCHPFuelUsed
     m[:ExpectedMGFuelCost] += ExpectedMGCHPFuelCost
 end
 

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -466,6 +466,10 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
 
     prime_mover_defaults = get_prime_mover_defaults(prime_mover, hot_water_or_steam, size_class, prime_mover_defaults_all)
 
+    if !isnothing(chp_max_size_kw) && prime_mover_defaults["min_allowable_kw"] > chp_max_size_kw
+        prime_mover_defaults["min_allowable_kw"] = chp_max_size_kw
+    end
+
     response = Dict([
         ("prime_mover", prime_mover),
         ("size_class", size_class),

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -29,6 +29,7 @@
 # *********************************************************************************
 
 prime_movers = ["recip_engine", "micro_turbine", "combustion_turbine", "fuel_cell"]
+conflict_res_min_allowable_fraction_of_max = 0.25
 
 """
 `CHP` is an optional REopt input with the following keys and default values:
@@ -260,8 +261,8 @@ function CHP(d::Dict;
     end
 
     if chp.min_allowable_kw > chp.max_kw
-        @warn "CHP.min_allowable_kw is greater than CHP.max_kw, so setting min_allowable_kw equal to max_kw"
-        setproperty!(chp, :min_allowable_kw, chp.max_kw)
+        @warn "CHP.min_allowable_kw is greater than CHP.max_kw, so setting min_allowable_kw equal to $conflict_res_min_allowable_fraction_of_max of the max_kw"
+        setproperty!(chp, :min_allowable_kw, chp.max_kw * conflict_res_min_allowable_fraction_of_max)
     end
         
     if isempty(chp.unavailability_periods)
@@ -476,7 +477,7 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
     prime_mover_defaults = get_prime_mover_defaults(prime_mover, hot_water_or_steam, size_class, max_kw, prime_mover_defaults_all)
 
     if !isnothing(chp_max_size_kw) && prime_mover_defaults["min_allowable_kw"] > chp_max_size_kw
-        prime_mover_defaults["min_allowable_kw"] = chp_max_size_kw
+        prime_mover_defaults["min_allowable_kw"] = chp_max_size_kw * conflict_res_min_allowable_fraction_of_max
     end
 
     response = Dict([

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -414,11 +414,8 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
         else
             boiler_effic = boiler_efficiency
         end
-        therm_effic = prime_mover_defaults_all[prime_mover]["thermal_efficiency_full_load"][hot_water_or_steam][size_class_calc+1]
-        elec_effic = prime_mover_defaults_all[prime_mover]["electric_efficiency_full_load"][size_class_calc+1]
-        avg_heating_thermal_load_mmbtu_per_hr = avg_boiler_fuel_load_mmbtu_per_hour * boiler_effic
-        chp_fuel_rate_mmbtu_per_hr = avg_heating_thermal_load_mmbtu_per_hr / therm_effic
-        chp_elec_size_heuristic_kw = chp_fuel_rate_mmbtu_per_hr * elec_effic * KWH_PER_MMBTU
+        chp_elec_size_heuristic_kw = get_heuristic_chp_size_kw(prime_mover_defaults_all, avg_boiler_fuel_load_mmbtu_per_hour, 
+                                        prime_mover, size_class_calc, hot_water_or_steam, boiler_effic)
         chp_max_size_kw = 2 * chp_elec_size_heuristic_kw
     # Calculate heuristic CHP size based on average electric load, and max size based on peak electric load
     elseif !isnothing(avg_electric_load_kw) && !isnothing(max_electric_load_kw)
@@ -491,4 +488,15 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
     ])
     return response
 
+end
+
+function get_heuristic_chp_size_kw(prime_mover_defaults_all, avg_boiler_fuel_load_mmbtu_per_hour, 
+                                prime_mover, size_class, hot_water_or_steam, boiler_effic)
+    therm_effic = prime_mover_defaults_all[prime_mover]["thermal_efficiency_full_load"][hot_water_or_steam][size_class+1]
+    elec_effic = prime_mover_defaults_all[prime_mover]["electric_efficiency_full_load"][size_class+1]
+    avg_heating_thermal_load_mmbtu_per_hr = avg_boiler_fuel_load_mmbtu_per_hour * boiler_effic
+    chp_fuel_rate_mmbtu_per_hr = avg_heating_thermal_load_mmbtu_per_hr / therm_effic
+    chp_elec_size_heuristic_kw = chp_fuel_rate_mmbtu_per_hr * elec_effic * KWH_PER_MMBTU
+    
+    return chp_elec_size_heuristic_kw
 end

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -402,16 +402,28 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 		add_cannot_have_MG_with_only_PVwind_constraints(m,p)
 		add_MG_size_constraints(m,p)
 		
-		if !isempty(p.techs.gen)
-			add_MG_fuel_burn_constraints(m,p)
+		m[:ExpectedMGFuelUsed] = 0
+		m[:ExpectedMGFuelCost] = 0
+        if !isempty(p.techs.gen)
+			add_MG_Gen_fuel_burn_constraints(m,p)
 			add_binMGGenIsOnInTS_constraints(m,p)
 		else
-			m[:ExpectedMGFuelUsed] = 0
-			m[:ExpectedMGFuelCost] = 0
 			@constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
 				m[:binMGGenIsOnInTS][s, tz, ts] == 0
 			)
 		end
+
+		if !isempty(p.techs.chp)
+			add_MG_CHP_fuel_burn_constraints(m,p)
+			add_binMGCHPIsOnInTS_constraints(m,p)
+		else
+			@constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+				m[:binMGCHPIsOnInTS][s, tz, ts] == 0
+			)
+			@constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+				m[:dvMGCHPFuelBurnYIntercept][s, tz, ts] == 0
+			)            
+		end        
 		
 		if p.s.site.min_resil_time_steps > 0
 			add_min_hours_crit_ld_met_constraint(m,p)
@@ -634,7 +646,7 @@ function add_variables!(m::JuMP.AbstractModel, p::REoptInputs)
 		tZeros = p.s.electric_utility.outage_start_time_steps
 		S = p.s.electric_utility.scenarios
 		# TODO: currently defining more decision variables than necessary b/c using rectangular arrays, could use dicts of decision variables instead
-		@variables m begin # if there is more than one specified outage, there can be more othan one outage start time
+        @variables m begin # if there is more than one specified outage, there can be more othan one outage start time
 			dvUnservedLoad[S, tZeros, outage_time_steps] >= 0 # unserved load not met by system
 			dvMGProductionToStorage[p.techs.elec, S, tZeros, outage_time_steps] >= 0 # Electricity going to the storage system during each time_step
 			dvMGDischargeFromStorage[S, tZeros, outage_time_steps] >= 0 # Electricity coming from the storage system during each time_step
@@ -646,13 +658,17 @@ function add_variables!(m::JuMP.AbstractModel, p::REoptInputs)
 			dvMGsize[p.techs.elec] >= 0
 			
 			dvMGFuelUsed[p.techs.elec, S, tZeros] >= 0
-			dvMGMaxFuelUsage[S] >= 0
-			dvMGMaxFuelCost[S] >= 0
+            dvMGGenMaxFuelUsage[S] >= 0
+            dvMGCHPMaxFuelUsage[S] >= 0
+			dvMGGenMaxFuelCost[S] >= 0
+            dvMGCHPMaxFuelCost[S] >= 0
 			dvMGCurtail[p.techs.elec, S, tZeros, outage_time_steps] >= 0
 
 			binMGStorageUsed, Bin # 1 if MG storage battery used, 0 otherwise
 			binMGTechUsed[p.techs.elec], Bin # 1 if MG tech used, 0 otherwise
 			binMGGenIsOnInTS[S, tZeros, outage_time_steps], Bin
+            binMGCHPIsOnInTS[S, tZeros, outage_time_steps], Bin
+            dvMGCHPFuelBurnYIntercept[S, tZeros] >= 0
 		end
 	end
 

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -401,8 +401,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 		end
 		add_cannot_have_MG_with_only_PVwind_constraints(m,p)
 		add_MG_size_constraints(m,p)
-		
-		m[:ExpectedMGFuelUsed] = 0
+		0
 		m[:ExpectedMGFuelCost] = 0
         if !isempty(p.techs.gen)
 			add_MG_Gen_fuel_burn_constraints(m,p)

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -421,7 +421,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 				m[:binMGCHPIsOnInTS][s, tz, ts] == 0
 			)
 			@constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-				m[:dvMGCHPFuelBurnYIntercept][s, tz, ts] == 0
+				m[:dvMGCHPFuelBurnYIntercept][s, tz] == 0
 			)            
 		end        
 		

--- a/src/core/simulated_load.jl
+++ b/src/core/simulated_load.jl
@@ -222,7 +222,7 @@ function simulated_load(d::Dict)
         # Monthly loads (default is empty list)
         monthly_mmbtu = get(d, "monthly_mmbtu", Real[])
         if !isempty(monthly_mmbtu)
-            if length(monthly_mmbtu != 12)
+            if length(monthly_mmbtu) != 12
                 throw(@error("monthly_mmbtu must contain a value for each of the 12 months"))
             end                   
             bad_index = []
@@ -279,11 +279,11 @@ function simulated_load(d::Dict)
         space_heating_monthly_mmbtu = Real[]
         dhw_monthly_mmbtu = Real[]
         if !isempty(monthly_mmbtu)    
-            space_heating_monthly_energy = get_monthly_energy(power_profile=default_space_heating_load.loads_kw)
-            dhw_monthly_energy = get_monthly_energy(power_profile=default_dhw_load.loads_kw)
+            space_heating_monthly_energy = get_monthly_energy(default_space_heating_load.loads_kw)
+            dhw_monthly_energy = get_monthly_energy(default_dhw_load.loads_kw)
             space_heating_fraction_monthly = space_heating_monthly_energy ./ (space_heating_monthly_energy + dhw_monthly_energy)
             space_heating_monthly_mmbtu = monthly_mmbtu .* space_heating_fraction_monthly
-            dhw_monthly_mmbtu = monthly_mmbtu .* (1 .- space_heating_monthly_mmbtu)
+            dhw_monthly_mmbtu = monthly_mmbtu - space_heating_monthly_mmbtu
         elseif !isnothing(annual_mmbtu)
             total_heating_annual_mmbtu = default_space_heating_load.annual_mmbtu + default_dhw_load.annual_mmbtu
             space_heating_fraction = default_space_heating_load.annual_mmbtu / total_heating_annual_mmbtu

--- a/test/scenarios/outage.json
+++ b/test/scenarios/outage.json
@@ -13,6 +13,13 @@
         "only_runs_during_grid_outage": true,
         "sells_energy_back_to_grid": false
     },
+    "CHP": {
+        "thermal_efficiency_full_load": 0.0,
+        "prime_mover": "recip_engine",
+        "fuel_cost_per_mmbtu": 12.0,
+        "min_kw": 150.0,
+        "max_kw": 150.0
+    },    
     "PV": {
         "existing_kw": 3580.54,
         "array_type": 0,

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -484,7 +484,7 @@ end
 
 @testset "Minimize Unserved Load" begin
         
-    m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
+    m = Model(optimizer_with_attributes(Xpress.Optimizer, "MIPRELSTOP" => 0.01, "OUTPUTLOG" => 0))
     results = run_reopt(m, "./scenarios/outage.json")
 
     @test results["Outages"]["expected_outage_cost"] ≈ 0

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -490,9 +490,10 @@ end
     @test results["Outages"]["expected_outage_cost"] ≈ 0
     @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 0
     @test value(m[:binMGTechUsed]["Generator"]) ≈ 1
+    @test value(m[:binMGTechUsed]["CHP"]) ≈ 1
     @test value(m[:binMGTechUsed]["PV"]) ≈ 1
     @test value(m[:binMGStorageUsed]) ≈ 1
-    @test results["Financial"]["lcc"] ≈ 7.19753998668e7 atol=5e4
+    @test results["Financial"]["lcc"] ≈ 7.0176719775e7 atol=5e4
 
     #=
     Scenario with $0.001/kWh value_of_lost_load_per_kwh, 12x169 hour outages, 1kW load/hour, and min_resil_time_steps = 168


### PR DESCRIPTION
- Add `CHP` `FuelUsed` and `FuelCost` modeling/tracking for stochastic/multi-outages
- Add `CHP` outputs for stochastic/multi-outages
- Add conditional logic to make `CHP.min_allowable_kw` 25% of `max_kw` if there is a conflicting relationship 
- Iterate on calculating `CHP` heuristic size based on average heating load which is also used to set `max_kw` if not given: once `size_class` is determined, recalculate using the efficiency numbers for that `size_class`.
- Fix non-handling of cost-curve/segmented techs in stochastic outages
- Fix issues with `simulated_load.jl` monthly heating energy input to return the heating load profile