### PR TITLE
Make outages output names not dynamic, add units to outages results, microgrid_upgrade_cost_fraction default to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## Develop 3/22/23
+### Changed
+- Made outages output names not dynamic to allow integration into API
+- Add missing units to outages results field names: **unserved_load_series_kw**, **unserved_load_per_outage_kwh**, **generator_fuel_used_per_outage_gal**
+- Default `Financial` field **microgrid_upgrade_cost_fraction** to 0
+
 ## v0.28.1
 ### Added
 - `emissions_profiles` function, exported for external use as an endpoint in REopt_API for the webtool/UI

--- a/src/core/financial.jl
+++ b/src/core/financial.jl
@@ -43,7 +43,7 @@
     owner_discount_rate_fraction::Real = 0.0564,
     analysis_years::Int = 25,
     value_of_lost_load_per_kwh::Union{Array{R,1}, R} where R<:Real = 1.00, #only applies to multiple outage modeling
-    microgrid_upgrade_cost_fraction::Real = off_grid_flag ? 0.0 : 0.3, # not applicable when `off_grid_flag` is true
+    microgrid_upgrade_cost_fraction::Real = 0.0
     macrs_five_year::Array{Float64,1} = [0.2, 0.32, 0.192, 0.1152, 0.1152, 0.0576],  # IRS pub 946
     macrs_seven_year::Array{Float64,1} = [0.1429, 0.2449, 0.1749, 0.1249, 0.0893, 0.0892, 0.0893, 0.0446],
     offgrid_other_capital_costs::Real = 0.0, # only applicable when `off_grid_flag` is true. Straight-line depreciation is applied to this capex cost, reducing taxable income.
@@ -117,7 +117,7 @@ struct Financial
         owner_discount_rate_fraction::Real = 0.0564,
         analysis_years::Int = 25,
         value_of_lost_load_per_kwh::Union{Array{<:Real,1}, Real} = 1.00, #only applies to multiple outage modeling
-        microgrid_upgrade_cost_fraction::Real = off_grid_flag ? 0.0 : 0.3, # not applicable when `off_grid_flag` is true
+        microgrid_upgrade_cost_fraction::Real = 0.0,
         macrs_five_year::Array{<:Real,1} = [0.2, 0.32, 0.192, 0.1152, 0.1152, 0.0576],  # IRS pub 946
         macrs_seven_year::Array{<:Real,1} = [0.1429, 0.2449, 0.1749, 0.1249, 0.0893, 0.0892, 0.0893, 0.0446],
         offgrid_other_capital_costs::Real = 0.0, # only applicable when `off_grid_flag` is true. Straight-line depreciation is applied to this capex cost, reducing taxable income.

--- a/src/results/outages.jl
+++ b/src/results/outages.jl
@@ -89,7 +89,7 @@ function add_outage_results(m, p, d::Dict)
 	r["unserved_load_per_outage_kwh"] = round.(unserved_load_per_outage, digits=2)
 	r["storage_microgrid_upgrade_cost"] = value(m[:dvMGStorageUpgradeCost])
 	r["microgrid_upgrade_capital_cost"] = r["storage_microgrid_upgrade_cost"]
-	if !isempty(p.s.storage.types.elec) && round(value(m[:binMGStorageUsed]), digits=0)
+	if !isempty(p.s.storage.types.elec) && Bool(round(value(m[:binMGStorageUsed]), digits=0))
 		r["storage_discharge_series_kw"] = value.(m[:dvMGDischargeFromStorage]).data
 	else
 		r["storage_discharge_series_kw"] = []

--- a/src/results/outages.jl
+++ b/src/results/outages.jl
@@ -95,11 +95,6 @@ function add_outage_results(m, p, d::Dict)
 		r["storage_discharge_series"] = []
 	end
 
-	# for t in p.techs.all
-	# 	r[t * "_microgrid_upgraded"] = round(value(m[:binMGTechUsed][t]), digits=0)
-	# end
-	# r["storage_microgrid_upgraded"] = round(value(m[:binMGStorageUsed]), digits=0)
-
 	if !isempty(p.techs.pv)
 		r["pv_microgrid_size_kw"] = round(
 			sum(

--- a/src/results/outages.jl
+++ b/src/results/outages.jl
@@ -125,8 +125,7 @@ function add_outage_results(m, p, d::Dict)
 									ts in p.s.electric_utility.outage_time_steps
 							) 
 							for t in tech_set
-						),
-						dims=1
+						)
 					), 
 					digits=3
 				)
@@ -141,8 +140,7 @@ function add_outage_results(m, p, d::Dict)
 								ts in p.s.electric_utility.outage_time_steps
 						) 
 						for t in tech_set
-					),
-					dims=1
+					)
 				), 
 				digits=3
 			)
@@ -158,8 +156,7 @@ function add_outage_results(m, p, d::Dict)
 								ts in p.s.electric_utility.outage_time_steps
 						) 
 						for t in tech_set
-					),
-					dims=1
+					)
 				), 
 				digits=3
 			)
@@ -168,9 +165,9 @@ function add_outage_results(m, p, d::Dict)
 	end
 
 	if !isempty(p.techs.gen)
-		r["generator_fuel_used_per_outage_gal"] = round(
+		r["generator_fuel_used_per_outage_gal"] = round.(
 			sum(
-				value.(m[:dvMGFuelUsed][t, :, :]).data for t in p.techs.gen
+				[value.(m[:dvMGFuelUsed][t, :, :]).data for t in p.techs.gen]
 			), 
 			digits=4
 		)

--- a/test/scenarios/emissions.json
+++ b/test/scenarios/emissions.json
@@ -71,6 +71,7 @@
         "analysis_years": 20,
         "offtaker_tax_rate_fraction": 0.4,
         "owner_tax_rate_fraction": 0.4,
-        "om_cost_escalation_rate_fraction": 0.025
+        "om_cost_escalation_rate_fraction": 0.025,
+        "microgrid_upgrade_cost_fraction": 0.3
     }
 }

--- a/test/scenarios/nogridcost_minresilhours.json
+++ b/test/scenarios/nogridcost_minresilhours.json
@@ -62,6 +62,7 @@
   "Generator": {
   },
   "Financial": {
-    "value_of_lost_load_per_kwh": 0.001
+    "value_of_lost_load_per_kwh": 0.001,
+    "microgrid_upgrade_cost_fraction": 0.3
   }
 }

--- a/test/scenarios/nogridcost_multiscenario.json
+++ b/test/scenarios/nogridcost_multiscenario.json
@@ -56,6 +56,7 @@
 	  "max_kw": 0.0
   },
   "Financial": {
-    "value_of_lost_load_per_kwh": 1.0
+    "value_of_lost_load_per_kwh": 1.0,
+    "microgrid_upgrade_cost_fraction": 0.3
   }
 }

--- a/test/scenarios/outage.json
+++ b/test/scenarios/outage.json
@@ -50,6 +50,7 @@
         "offtaker_tax_rate_fraction": 0.0,
         "owner_discount_rate_fraction": 0.1,
         "offtaker_discount_rate_fraction": 0.03,
-        "elec_cost_escalation_rate_fraction": 0.023
+        "elec_cost_escalation_rate_fraction": 0.023,
+        "microgrid_upgrade_cost_fraction": 0.3
     }
 }

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -488,7 +488,7 @@ end
     results = run_reopt(m, "./scenarios/outage.json")
 
     @test results["Outages"]["expected_outage_cost"] ≈ 0
-    @test sum(results["Outages"]["unserved_load_per_outage"]) ≈ 0
+    @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 0
     @test value(m[:binMGTechUsed]["Generator"]) ≈ 1
     @test value(m[:binMGTechUsed]["PV"]) ≈ 1
     @test value(m[:binMGStorageUsed]) ≈ 1
@@ -500,12 +500,12 @@ end
     =#
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
     results = run_reopt(m, "./scenarios/nogridcost_minresilhours.json")
-    @test sum(results["Outages"]["unserved_load_per_outage"]) ≈ 12
+    @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 12
     
     # testing dvUnserved load, which would output 100 kWh for this scenario before output fix
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
     results = run_reopt(m, "./scenarios/nogridcost_multiscenario.json")
-    @test sum(results["Outages"]["unserved_load_per_outage"]) ≈ 60
+    @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 60
     @test results["Outages"]["expected_outage_cost"] ≈ 485.43270 atol=1.0e-5  #avg duration (3h) * load per time step (10) * present worth factor (16.18109)
     @test results["Outages"]["max_outage_cost_per_outage_duration"][1] ≈ 161.8109 atol=1.0e-5
 


### PR DESCRIPTION
### Changed
- Made outages output names not dynamic to allow integration into API
- Add missing units to outages results field names: **unserved_load_series_kw**, **unserved_load_per_outage_kwh**, **generator_fuel_used_per_outage_gal**
- Default `Financial` field **microgrid_upgrade_cost_fraction** to 0