### PR TITLE
PVWatts API Fix

### DIFF
--- a/src/core/production_factor.jl
+++ b/src/core/production_factor.jl
@@ -52,10 +52,11 @@ function get_production_factor(pv::PV, latitude::Real, longitude::Real; timefram
         "&gcr=", pv.gcr, "&inv_eff=", pv.inv_eff*100, "&timeframe=", timeframe, "&dataset=", dataset,
         "&radius=", pv.radius
     )
+    # println("PVWatts URL = ", url)
 
     try
         @info "Querying PVWatts for production_factor with " pv.name
-        r = HTTP.get(url, verbose=2)
+        r = HTTP.get(url, verbose=3)
         @info "Response received from PVWatts"
         response = JSON.parse(String(r.body))
         if r.status != 200

--- a/src/core/production_factor.jl
+++ b/src/core/production_factor.jl
@@ -56,7 +56,7 @@ function get_production_factor(pv::PV, latitude::Real, longitude::Real; timefram
 
     try
         @info "Querying PVWatts for production_factor with " pv.name
-        r = HTTP.get(url, keepalive=false, readtimeout=10, verbose=2)
+        r = HTTP.get(url, keepalive=false, readtimeout=10, verbose=1)
         @info "Response received from PVWatts"
         response = JSON.parse(String(r.body))
         if r.status != 200

--- a/src/core/production_factor.jl
+++ b/src/core/production_factor.jl
@@ -52,11 +52,11 @@ function get_production_factor(pv::PV, latitude::Real, longitude::Real; timefram
         "&gcr=", pv.gcr, "&inv_eff=", pv.inv_eff*100, "&timeframe=", timeframe, "&dataset=", dataset,
         "&radius=", pv.radius
     )
-    # println("PVWatts URL = ", url)
+    println("PVWatts URL = ", url)
 
     try
         @info "Querying PVWatts for production_factor with " pv.name
-        r = HTTP.get(url, verbose=3)
+        r = HTTP.get(url, keepalive=false, readtimeout=10, verbose=2)
         @info "Response received from PVWatts"
         response = JSON.parse(String(r.body))
         if r.status != 200

--- a/src/core/production_factor.jl
+++ b/src/core/production_factor.jl
@@ -52,11 +52,10 @@ function get_production_factor(pv::PV, latitude::Real, longitude::Real; timefram
         "&gcr=", pv.gcr, "&inv_eff=", pv.inv_eff*100, "&timeframe=", timeframe, "&dataset=", dataset,
         "&radius=", pv.radius
     )
-    println("PVWatts URL = ", url)
 
     try
         @info "Querying PVWatts for production_factor with " pv.name
-        r = HTTP.get(url, keepalive=false, readtimeout=10, verbose=1)
+        r = HTTP.get(url, keepalive=true, readtimeout=10)
         @info "Response received from PVWatts"
         response = JSON.parse(String(r.body))
         if r.status != 200

--- a/src/core/production_factor.jl
+++ b/src/core/production_factor.jl
@@ -55,7 +55,8 @@ function get_production_factor(pv::PV, latitude::Real, longitude::Real; timefram
 
     try
         @info "Querying PVWatts for production_factor with " pv.name
-        r = HTTP.get(url)
+        r = HTTP.get(url, verbose=2)
+        @info "Response received from PVWatts"
         response = JSON.parse(String(r.body))
         if r.status != 200
             throw(@error("Bad response from PVWatts: $(response["errors"])"))

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -122,23 +122,23 @@ end
 
 
 """
-    run_reopt(ms::AbstractArray{T, 1}, fp::String; threads=true) where T <: JuMP.AbstractModel
+    run_reopt(ms::AbstractArray{T, 1}, fp::String) where T <: JuMP.AbstractModel
 
 Solve the `Scenario` and `BAUScenario` in parallel using the first two (empty) models in `ms` and inputs defined in the
 JSON file at the filepath `fp`.
 """
-function run_reopt(ms::AbstractArray{T, 1}, fp::String; threads=true) where T <: JuMP.AbstractModel
+function run_reopt(ms::AbstractArray{T, 1}, fp::String) where T <: JuMP.AbstractModel
 	d = JSON.parsefile(fp)
-    run_reopt(ms, d; threads=threads)
+    run_reopt(ms, d)
 end
 
 
 """
-    run_reopt(ms::AbstractArray{T, 1}, d::Dict; threads=true) where T <: JuMP.AbstractModel
+    run_reopt(ms::AbstractArray{T, 1}, d::Dict) where T <: JuMP.AbstractModel
 
 Solve the `Scenario` and `BAUScenario` in parallel using the first two (empty) models in `ms` and inputs from `d`.
 """
-function run_reopt(ms::AbstractArray{T, 1}, d::Dict; threads=true) where T <: JuMP.AbstractModel
+function run_reopt(ms::AbstractArray{T, 1}, d::Dict) where T <: JuMP.AbstractModel
 
 	try
 		s = Scenario(d)
@@ -148,7 +148,7 @@ function run_reopt(ms::AbstractArray{T, 1}, d::Dict; threads=true) where T <: Ju
 			return results
 		end
 	
-		run_reopt(ms, REoptInputs(s); threads=threads)		
+		run_reopt(ms, REoptInputs(s))		
 	catch e
 		if isnothing(e) # Error thrown by REopt
 			handle_errors()
@@ -159,24 +159,19 @@ function run_reopt(ms::AbstractArray{T, 1}, d::Dict; threads=true) where T <: Ju
 end
 
 """
-    run_reopt(ms::AbstractArray{T, 1}, p::REoptInputs; threads=true) where T <: JuMP.AbstractModel
+    run_reopt(ms::AbstractArray{T, 1}, p::REoptInputs) where T <: JuMP.AbstractModel
 
 Solve the `Scenario` and `BAUScenario` in parallel using the first two (empty) models in `ms` and inputs from `p`.
 """
-function run_reopt(ms::AbstractArray{T, 1}, p::REoptInputs; threads=true) where T <: JuMP.AbstractModel
+function run_reopt(ms::AbstractArray{T, 1}, p::REoptInputs) where T <: JuMP.AbstractModel
 
 	try
 		bau_inputs = BAUInputs(p)
 		inputs = ((ms[1], bau_inputs), (ms[2], p))
 		rs = Any[0, 0]
-        if threads
-            Threads.@threads for i = 1:2
-                rs[i] = run_reopt(inputs[i])
-            end
-        else
-            rs[1] = run_reopt(inputs[1])
-            rs[2] = run_reopt(inputs[2])
-        end
+		Threads.@threads for i = 1:2
+			rs[i] = run_reopt(inputs[i])
+		end
 		if typeof(rs[1]) <: Dict && typeof(rs[2]) <: Dict
 			# TODO when a model is infeasible the JuMP.Model is returned from run_reopt (and not the results Dict)
 			results_dict = combine_results(p, rs[1], rs[2], bau_inputs.s)


### PR DESCRIPTION
Issue:
PVWatts API connection periodically hangs for a long time (15+ minutes) when using REopt.jl which calls the PVWatts API on our Rancher servers.

Fix: 
Add a timeout so that if it does not connect within 10 seconds, it will retry and we've seen it work on the first retry.