### PR TITLE
Handle matrix type urdb demand fields

### DIFF
--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -318,7 +318,7 @@ Convert an unexpected type::Matrix from URDB into an Array
     - Observed while using REopt.jl with PyJulia/PyCall
 """
 function convert_matrix_to_array(M::AbstractMatrix)
-    return [M[:,c] for c in eachindex(M,2)]
+    return [M[:,c] for c in 1:size(M,2)]
 end
 
 """

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -97,7 +97,7 @@ function URDBrate(urdb_response::Dict, year::Int; time_steps_per_hour=1)
     demand_min = get(urdb_response, "peakkwcapacitymin", 0.0)  # TODO add check for site min demand against tariff?
 
     # Convert matrix to array if needed
-    possible_matrix = ["demandratestructure", "flatdemandstructure" "demandweekdayschedule", 
+    possible_matrix = ["demandratestructure", "flatdemandstructure", "demandweekdayschedule", 
         "demandweekendschedule", "energyratestructure", "energyweekdayschedule", "energyweekendschedule"]
     for param in possible_matrix
         if haskey(d, param) && typeof(param) <: AbstractMatrix

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -100,8 +100,8 @@ function URDBrate(urdb_response::Dict, year::Int; time_steps_per_hour=1)
     possible_matrix = ["demandratestructure", "flatdemandstructure", "demandweekdayschedule", 
         "demandweekendschedule", "energyratestructure", "energyweekdayschedule", "energyweekendschedule"]
     for param in possible_matrix
-        if haskey(d, param) && typeof(param) <: AbstractMatrix
-            d[param] = convert_matrix_to_array(d[param])
+        if haskey(urdb_response, param) && typeof(param) <: AbstractMatrix
+            urdb_response[param] = convert_matrix_to_array(urdb_response[param])
         end
     end
 

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -100,7 +100,7 @@ function URDBrate(urdb_response::Dict, year::Int; time_steps_per_hour=1)
     possible_matrix = ["demandratestructure", "flatdemandstructure", "demandweekdayschedule", 
         "demandweekendschedule", "energyratestructure", "energyweekdayschedule", "energyweekendschedule"]
     for param in possible_matrix
-        if haskey(urdb_response, param) && typeof(param) <: AbstractMatrix
+        if typeof(get(urdb_response, param, nothing)) <: AbstractMatrix
             urdb_response[param] = convert_matrix_to_array(urdb_response[param])
         end
     end


### PR DESCRIPTION
When calling REopt.jl from a python environment using PyJulia and PyCall, some urdb_response fields get converted from a list-of-lists to a matrix type, when REopt.jl expects an array type. This PR adds checks on the type for two urdb_response fields and converts them to an array if needed.