### PR TITLE
Fix monthly cooling input type conversion

### DIFF
--- a/src/core/heating_cooling_loads.jl
+++ b/src/core/heating_cooling_loads.jl
@@ -736,7 +736,7 @@ function BuiltInDomesticHotWaterLoad(
         annual_mmbtu *= addressable_load_fraction     
     end
     if length(monthly_mmbtu) == 12
-        monthly_mmbtu = convert(Vector{Real}, monthly_mmbtu) .* addressable_load_fraction
+        monthly_mmbtu = monthly_mmbtu .* addressable_load_fraction
     end
     built_in_load("domestic_hot_water", city, buildingtype, year, annual_mmbtu, monthly_mmbtu)
 end
@@ -1075,7 +1075,7 @@ function BuiltInSpaceHeatingLoad(
         annual_mmbtu *= addressable_load_fraction
     end
     if length(monthly_mmbtu) == 12
-        monthly_mmbtu = convert(Vector{Real}, monthly_mmbtu) .* addressable_load_fraction
+        monthly_mmbtu = monthly_mmbtu .* addressable_load_fraction
     end
     built_in_load("space_heating", city, buildingtype, year, annual_mmbtu, monthly_mmbtu)
 end

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -183,7 +183,8 @@ function dictkeys_tosymbols(d::Dict)
             "emissions_factor_series_lb_SO2_per_kwh",
             "emissions_factor_series_lb_PM25_per_kwh",
             #for ERP
-            "pv_production_factor_series", "battery_starting_soc_series_fraction"
+            "pv_production_factor_series", "battery_starting_soc_series_fraction",
+            "monthly_mmbtu", "monthly_tonhour"
         ] && !isnothing(v)
             try
                 v = convert(Array{Real, 1}, v)


### PR DESCRIPTION
and make monthly heating type conversions consistent with other inputs.  This uses the branch from https://github.com/NREL/REopt.jl/pull/253 applying the monthly cooling input fix but merges this branch into `develop` instead of the cooling defaults update (which is no longer needed).