### PR TITLE
update error checking of whl length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Classify the change according to the following categories:
     ### Removed
 
 
+## Develop -- 2023-10-13
+### Fixed
+- Bug fix for user-supplied 8760 WHL rates with tiered energy rate
+
 ## v0.36.0 (pre-release)
 ### Changed
 - Changed default values by prime mover for CHP technologies in `data/chp/chp_defaults.json`.  See user manual for details by prime mover and size class.

--- a/src/core/electric_tariff.jl
+++ b/src/core/electric_tariff.jl
@@ -294,11 +294,11 @@ function ElectricTariff(;
     - if NEM then set ExportRate[:Nem, :] to energy_rate[tier_with_lowest_energy_rate, :]
     - user can provide either scalar wholesale rate or vector of time_steps, 
     =#
-    whl_rate = create_export_rate(wholesale_rate, length(energy_rates), time_steps_per_hour)
+    whl_rate = create_export_rate(wholesale_rate, length(energy_rates[:,1]), time_steps_per_hour)
     if !isnothing(u) && sum(u.sell_rates) < 0
         whl_rate += u.sell_rates
     end
-    exc_rate = create_export_rate(export_rate_beyond_net_metering_limit, length(energy_rates), time_steps_per_hour)
+    exc_rate = create_export_rate(export_rate_beyond_net_metering_limit, length(energy_rates[:,1]), time_steps_per_hour)
     
     if !NEM & (sum(whl_rate) >= 0) # no NEM or WHL 
         export_rates = Dict{Symbol, AbstractArray}()

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -153,7 +153,7 @@ function run_reopt(ms::AbstractArray{T, 1}, p::REoptInputs) where T <: JuMP.Abst
 			end
 			return results_dict
 		else
-			throw(@error("REopt scenarios solved either with errors of non-optimal solutions."))
+			throw(@error("REopt scenarios solved either with errors or non-optimal solutions."))
 		end
 	catch e
 		if isnothing(e) # Error thrown by REopt

--- a/src/mpc/structs.jl
+++ b/src/mpc/structs.jl
@@ -173,7 +173,7 @@ function MPCElectricTariff(d::Dict)
     if !isnothing(export_rates)
         export_rates = convert(Vector{Real}, export_rates)
     end
-    whl_rate = create_export_rate(export_rates, length(energy_rates), 1)
+    whl_rate = create_export_rate(export_rates, length(energy_rates[:,1]), 1)
 
     if !NEM & (sum(whl_rate) >= 0)
         export_rates = DenseAxisArray{Array{Float64,1}}(undef, [])


### PR DESCRIPTION
Previously: 
- If you uploaded an 8760 WHL rate 
- And had an energy rate with tiers
- REopt checked that length of whl == length of energy_rates. 
- If energy_rates has tiers and is thus a 2D matrix (8760,2), the length of energy_rates = 8760*2 = 17520 and REopt will error

Now:
- Instead check that length of whl = length(energy_rates[:1]) 