### PR TITLE
Fix assignment of thermal_effic half = full if not input

### DIFF
--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -229,7 +229,7 @@ function CHP(d::Dict;
         chp.electric_efficiency_half_load = chp.electric_efficiency_full_load
     end
     if isnan(chp.thermal_efficiency_half_load)
-        chp.thermal_efficiency_half_load = chp.electric_efficiency_full_load
+        chp.thermal_efficiency_half_load = chp.thermal_efficiency_full_load
     end
 
     if isnan(chp.max_kw)


### PR DESCRIPTION
This was erroneously equating thermal efficiency to electric efficiency for half load