### PR TITLE
Fix CHP-Only Resilience and Negative Intercept

### DIFF
--- a/src/constraints/chp_constraints.jl
+++ b/src/constraints/chp_constraints.jl
@@ -11,7 +11,7 @@ function add_chp_fuel_burn_constraints(m, p; _n="")
         sum(p.pwf_fuel[t] * m[:dvFuelUsage][t, ts] * p.fuel_cost_per_kwh[t][ts] for t in p.techs.chp, ts in p.time_steps)
     )      
     # Conditionally add dvFuelBurnYIntercept if coefficient p.FuelBurnYIntRate is greater than ~zero
-    if fuel_burn_intercept > 1.0E-7
+    if abs(fuel_burn_intercept) > 1.0E-7
         dv = "dvFuelBurnYIntercept"*_n
         m[Symbol(dv)] = @variable(m, [p.techs.chp, p.time_steps], base_name=dv, lower_bound=0)
 
@@ -47,9 +47,9 @@ function add_chp_thermal_production_constraints(m, p; _n="")
     thermal_prod_intercept = thermal_prod_full_load - thermal_prod_slope * 1.0  # [kWt/kWe_rated
 
     # Conditionally add dvThermalProductionYIntercept if coefficient p.s.chpThermalProdIntercept is greater than ~zero
-    if thermal_prod_intercept > 1.0E-7
+    if abs(thermal_prod_intercept) > 1.0E-7
         dv = "dvThermalProductionYIntercept"*_n
-        m[Symbol(dv)] = @variable(m, [p.techs.chp, p.time_steps], base_name=dv, lower_bound=0)
+        m[Symbol(dv)] = @variable(m, [p.techs.chp, p.time_steps], base_name=dv)
 
         #Constraint (2a-1): Upper Bounds on Thermal Production Y-Intercept
         @constraint(m, CHPYInt2a1Con[t in p.techs.chp, ts in p.time_steps],

--- a/src/constraints/chp_constraints.jl
+++ b/src/constraints/chp_constraints.jl
@@ -13,7 +13,7 @@ function add_chp_fuel_burn_constraints(m, p; _n="")
     # Conditionally add dvFuelBurnYIntercept if coefficient p.FuelBurnYIntRate is greater than ~zero
     if abs(fuel_burn_intercept) > 1.0E-7
         dv = "dvFuelBurnYIntercept"*_n
-        m[Symbol(dv)] = @variable(m, [p.techs.chp, p.time_steps], base_name=dv, lower_bound=0)
+        m[Symbol(dv)] = @variable(m, [p.techs.chp, p.time_steps], base_name=dv)
 
         #Constraint (1c1): Total Fuel burn for CHP **with** y-intercept fuel burn and supplementary firing
         @constraint(m, CHPFuelBurnCon[t in p.techs.chp, ts in p.time_steps],

--- a/src/constraints/load_balance.jl
+++ b/src/constraints/load_balance.jl
@@ -116,7 +116,7 @@ function add_thermal_load_constraints(m, p; _n="")
         if !isempty(p.techs.heating)
             
             if !isempty(p.techs.steam_turbine)
-                @constraint(m, [ts in p.time_steps],
+                @constraint(m, [ts in p.time_steps_with_grid],
                     sum(m[Symbol("dvThermalProduction"*_n)][t,ts] for t in union(p.techs.heating, p.techs.chp))
                     + sum(m[Symbol("dvDischargeFromStorage"*_n)][b,ts] for b in p.s.storage.types.hot)
                     + sum(p.ghp_heating_thermal_load_served_kw[g,ts] * m[Symbol("binGHP"*_n)][g] for g in p.ghp_options)
@@ -129,7 +129,7 @@ function add_thermal_load_constraints(m, p; _n="")
                     + sum(m[Symbol("dvThermalToSteamTurbine"*_n)][t,ts] for t in p.techs.can_supply_steam_turbine)
                 )
             else
-                @constraint(m, [ts in p.time_steps],
+                @constraint(m, [ts in p.time_steps_with_grid],
                     sum(m[Symbol("dvThermalProduction"*_n)][t,ts] for t in union(p.techs.heating, p.techs.chp))
                     + sum(m[Symbol("dvDischargeFromStorage"*_n)][b,ts] for b in p.s.storage.types.hot)
                     + sum(p.ghp_heating_thermal_load_served_kw[g,ts] * m[Symbol("binGHP"*_n)][g] for g in p.ghp_options)

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -145,7 +145,7 @@ function add_MG_CHP_fuel_burn_constraints(m, p; _n="")
     fuel_burn_intercept = fuel_burn_full_load - fuel_burn_slope * 1.0  # [kWt/kWe_rated]
   
     # Conditionally add dvFuelBurnYIntercept if coefficient p.FuelBurnYIntRate is greater than ~zero
-    if fuel_burn_intercept > 1.0E-7
+    if abs(fuel_burn_intercept) > 1.0E-7
         #Constraint (1c1): Total Fuel burn for CHP **with** y-intercept fuel burn and supplementary firing
         @constraint(m, MGCHPFuelBurnCon[t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps],
             m[Symbol("dvMGFuelUsed"*_n)][t,s,tz]  == p.hours_per_time_step * (

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -297,7 +297,7 @@ end
 
 
 function add_cannot_have_MG_with_only_PVwind_constraints(m, p)
-    renewable_techs = setdiff(p.techs.elec, p.techs.gen)
+    renewable_techs = setdiff(p.techs.elec, p.techs.gen, p.techs.chp)
     # can't "turn down" renewable_techs
     if !isempty(renewable_techs)
         @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],

--- a/src/results/chp.jl
+++ b/src/results/chp.jl
@@ -90,10 +90,10 @@ function add_chp_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
             for t in p.techs.chp) - CHPtoHotTES[ts] - CHPToSteamTurbineKW[ts] - CHPThermalToWasteKW[ts])
     r["thermal_to_load_series_mmbtu_per_hour"] = round.(value.(CHPThermalToLoadKW) / KWH_PER_MMBTU, digits=5)
 	r["year_one_fuel_cost_before_tax"] = round(value(m[:TotalCHPFuelCosts] / p.pwf_fuel["CHP"]), digits=3)                
-	r["lifecycle_fuel_cost_after_tax"] = round(value(m[:TotalCHPFuelCosts]) * p.s.financial.offtaker_tax_rate_fraction, digits=3)
+	r["lifecycle_fuel_cost_after_tax"] = round(value(m[:TotalCHPFuelCosts]) * (1- p.s.financial.offtaker_tax_rate_fraction), digits=3)
 	#Standby charges and hourly O&M
 	r["year_one_standby_cost_before_tax"] = round(value(m[Symbol("TotalCHPStandbyCharges")]) / p.pwf_e, digits=0)
-	r["lifecycle_standby_cost_after_tax"] = round(value(m[Symbol("TotalCHPStandbyCharges")]) * p.s.financial.offtaker_tax_rate_fraction, digits=0)
+	r["lifecycle_standby_cost_after_tax"] = round(value(m[Symbol("TotalCHPStandbyCharges")]) * (1 - p.s.financial.offtaker_tax_rate_fraction), digits=0)
 
 
     d["CHP"] = r

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -465,7 +465,7 @@ end
     @test value(m[:binMGTechUsed]["CHP"]) ≈ 1
     @test value(m[:binMGTechUsed]["PV"]) ≈ 1
     @test value(m[:binMGStorageUsed]) ≈ 1
-    @test results["Financial"]["lcc"] ≈ 6.83746678985e7 atol=5e4
+    @test results["Financial"]["lcc"] ≈ 6.85650648412e7 atol=5e4
 
     #=
     Scenario with $0.001/kWh value_of_lost_load_per_kwh, 12x169 hour outages, 1kW load/hour, and min_resil_time_steps = 168


### PR DESCRIPTION
- CHP-only with multiple outages was erroring because it was not being removed from the list of techs for renewable_techs in outage_constraints.jl, so the model was not allowing it to serve critical load during an outage by itself.
- The fuel_burn and thermal_prod intercepts were also not being allowed to go negative, which is valid.
- Fixed after-tax CHP LCC results