### PR TITLE
Remove min turndown for CHP for outages

### DIFF
--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -217,11 +217,6 @@ function add_binMGCHPIsOnInTS_constraints(m, p; _n="")
         !m[:binMGCHPIsOnInTS][s, tz, ts] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
     )
     @constraint(m, [t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-        m[:binMGCHPIsOnInTS][s, tz, ts] => { 
-            m[:dvMGRatedProduction][t, s, tz, ts] >= p.s.chp.min_turn_down_fraction * m[:dvMGsize][t]
-        }
-    )
-    @constraint(m, [t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
         m[:binMGTechUsed][t] >= m[:binMGCHPIsOnInTS][s, tz, ts]
     )
     # TODO? make binMGCHPIsOnInTS indexed on p.techs.chp    

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -465,7 +465,7 @@ end
     @test value(m[:binMGTechUsed]["CHP"]) ≈ 1
     @test value(m[:binMGTechUsed]["PV"]) ≈ 1
     @test value(m[:binMGStorageUsed]) ≈ 1
-    @test results["Financial"]["lcc"] ≈ 6.85650648412e7 atol=5e4
+    @test results["Financial"]["lcc"] ≈ 6.83633907986e7 atol=5e4
 
     #=
     Scenario with $0.001/kWh value_of_lost_load_per_kwh, 12x169 hour outages, 1kW load/hour, and min_resil_time_steps = 168


### PR DESCRIPTION
- Remove min turndown for CHP for outages
  - Change expected lower lcc in test due to CHP being able to turn down lower