### PR TITLE
Ignore CHP unavailability during multiple outages

### DIFF
--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -123,7 +123,7 @@ function add_MG_Gen_fuel_burn_constraints(m,p)
 
     # fuel cost = gallons * $/gal for each tech, outage
     @expression(m, MGFuelCost[t in p.techs.gen, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps],
-        m[:dvMGFuelUsed][t, s, tz] * p.s.generator.fuel_cost_per_gallon
+        m[:dvMGFuelUsed][t, s, tz] * p.s.generator.fuel_cost_per_gallon # why not: * p.pwf_fuel[t] ?
     )
     
     @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps],
@@ -179,7 +179,7 @@ function add_MG_CHP_fuel_burn_constraints(m, p; _n="")
 
     # fuel cost = kWh * $/kWh
     @expression(m, MGCHPFuelCost[t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps],
-        m[:dvMGFuelUsed][t, s, tz] * p.fuel_cost_per_kwh[t][tz]
+        m[:dvMGFuelUsed][t, s, tz] * p.fuel_cost_per_kwh[t][tz] # why not: * p.pwf_fuel[t] ?
     )
     
     @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps],

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -1,9 +1,9 @@
 # REopt®, Copyright (c) Alliance for Sustainable Energy, LLC. See also https://github.com/NREL/REopt.jl/blob/master/LICENSE.
-function add_dv_UnservedLoad_constraints(m,p)
-    # effective load balance (with slack in dvUnservedLoad)
+function add_dv_UnservedLoad_constraints(m,p,unavailability)
+    # Effective load balance
     @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
         m[:dvUnservedLoad][s, tz, ts] == p.s.electric_load.critical_loads_kw[tz+ts-1]
-        - sum(  m[:dvMGRatedProduction][t, s, tz, ts] * p.production_factor[t, tz+ts-1] * p.levelization_factor[t]
+        - sum(  m[:dvMGRatedProduction][t, s, tz, ts] * (p.production_factor[t, tz+ts-1] + unavailability[t][tz+ts-1]) * p.levelization_factor[t]
               - m[:dvMGProductionToStorage][t, s, tz, ts] - m[:dvMGCurtail][t, s, tz, ts]
             for t in p.techs.elec
         )
@@ -76,12 +76,12 @@ function add_MG_size_constraints(m,p)
 end
 
 
-function add_MG_production_constraints(m,p)
+function add_MG_production_constraints(m,p,unavailability)
 
 	# Electrical production sent to storage or export must be less than technology's rated production
 	@constraint(m, [t in p.techs.elec, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
 		m[:dvMGProductionToStorage][t, s, tz, ts] + m[:dvMGCurtail][t, s, tz, ts] <=
-		p.production_factor[t, tz+ts-1] * p.levelization_factor[t] * m[:dvMGRatedProduction][t, s, tz, ts]
+		(p.production_factor[t, tz+ts-1] + unavailability[t][tz+ts-1]) * p.levelization_factor[t] * m[:dvMGRatedProduction][t, s, tz, ts]
     )
 
     @constraint(m, [t in p.techs.elec, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps], 
@@ -150,7 +150,7 @@ function add_MG_CHP_fuel_burn_constraints(m, p; _n="")
         @constraint(m, MGCHPFuelBurnCon[t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps],
             m[Symbol("dvMGFuelUsed"*_n)][t,s,tz]  == p.hours_per_time_step * (
                 m[Symbol("dvMGCHPFuelBurnYIntercept"*_n)][s,tz] +
-                sum(p.production_factor[t,tz+ts-1] * fuel_burn_slope * m[Symbol("dvMGRatedProduction"*_n)][t,s,tz,ts]
+                sum(fuel_burn_slope * m[Symbol("dvMGRatedProduction"*_n)][t,s,tz,ts]
                     for ts in 1:p.s.electric_utility.outage_durations[s]))
         )
 
@@ -164,7 +164,7 @@ function add_MG_CHP_fuel_burn_constraints(m, p; _n="")
         #Constraint (1c2): Total Fuel burn for CHP **without** y-intercept fuel burn
         @constraint(m, MGCHPFuelBurnConLinear[t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps],
             m[Symbol("dvMGFuelUsed"*_n)][t,s,tz]  == p.hours_per_time_step *
-                sum(p.production_factor[t,tz+ts-1] * fuel_burn_slope * m[Symbol("dvMGRatedProduction"*_n)][t,s,tz,ts]
+                sum(fuel_burn_slope * m[Symbol("dvMGRatedProduction"*_n)][t,s,tz,ts]
                 for ts in 1:p.s.electric_utility.outage_durations[s])
         )
     end 

--- a/src/core/production_factor.jl
+++ b/src/core/production_factor.jl
@@ -272,11 +272,11 @@ scheduled (mostly off-peak) and "unscheduled" (on-peak) maintenance.
 Note: this same prod_factor should be applied to electric and thermal production
 """
 function get_production_factor(chp::AbstractCHP, year::Int=2017, outage_start_time_step::Int=0, outage_end_time_step::Int=0, ts_per_hour::Int=1)
-    unavailability_hourly = generate_year_profile_hourly(year, chp.unavailability_periods)
+    
+    prod_factor = [1.0 - chp.unavailability_hourly[i] for i in 1:8760 for _ in 1:ts_per_hour]
 
-    prod_factor = [1.0 - unavailability_hourly[i] for i in 1:8760 for _ in 1:ts_per_hour]
-
-    # Ignore unavailability in time_step if it intersects with an outage interval
+    # Ignore unavailability in time_step if it intersects with an outage interval(s)
+    # This is handled differently with multiple/stochastic outages to preserve economic-impact of
     if outage_start_time_step != 0 && outage_end_time_step != 0
         prod_factor[outage_start_time_step:outage_end_time_step] .= ones(outage_end_time_step - outage_start_time_step + 1)
     end

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -365,9 +365,13 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 	add_elec_utility_expressions(m, p)
 
 	if !isempty(p.s.electric_utility.outage_durations)
-		add_dv_UnservedLoad_constraints(m,p)
+		unavailability = Dict(tech => zeros(length(p.time_steps)) for tech in p.techs.elec)
+        if !isempty(p.techs.chp)
+            unavailability["CHP"] = [p.s.chp.unavailability_hourly[i] for i in 1:8760 for _ in 1:p.s.settings.time_steps_per_hour]
+        end
+        add_dv_UnservedLoad_constraints(m,p,unavailability)
 		add_outage_cost_constraints(m,p)
-		add_MG_production_constraints(m,p)
+		add_MG_production_constraints(m,p,unavailability)
 		if !isempty(p.s.storage.types.elec)
 			add_MG_storage_dispatch_constraints(m,p)
 		else
@@ -375,7 +379,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 		end
 		add_cannot_have_MG_with_only_PVwind_constraints(m,p)
 		add_MG_size_constraints(m,p)
-		0
+		
 		m[:ExpectedMGFuelCost] = 0
         if !isempty(p.techs.gen)
 			add_MG_Gen_fuel_burn_constraints(m,p)

--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -326,7 +326,8 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
             chp = CHP(d["CHP"]; 
                     avg_boiler_fuel_load_mmbtu_per_hour = avg_boiler_fuel_load_mmbtu_per_hour,
                     existing_boiler = existing_boiler,
-                    electric_load_series_kw = electric_load.loads_kw)
+                    electric_load_series_kw = electric_load.loads_kw,
+                    year = electric_load.year)
         else # Only if modeling CHP without heating_load and existing_boiler (for prime generator, electric-only)
             chp = CHP(d["CHP"],
                     electric_load_series_kw = electric_load.loads_kw)


### PR DESCRIPTION
Currently,  inconsistent with the deterministic single outage scenario which ignores CHP unavailability during the outage, the stochastic multiple outages was not ignoring CHP unavailability. This PR changes that to ignore CHP unavailability during the outages, while preserving the unavailability periods for the 8760 grid-tied operation. This allows consistency in the economic dispatch between non-outages and outages scenarios.