### PR TITLE
Hot Fix: add year arg for electric-only CHP

### DIFF
--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -330,7 +330,8 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
                     year = electric_load.year)
         else # Only if modeling CHP without heating_load and existing_boiler (for prime generator, electric-only)
             chp = CHP(d["CHP"],
-                    electric_load_series_kw = electric_load.loads_kw)
+                    electric_load_series_kw = electric_load.loads_kw,
+                    year = electric_load.year)
         end
         chp_prime_mover = chp.prime_mover
     end


### PR DESCRIPTION
This fixes a discrepancy between the load profile and the year used for the CHP unavailability -> production factor, for electric-only CHP (Prime Generator)