### PR TITLE
Tiered demand rate bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Classify the change according to the following categories:
 ## Develop 2023-11-07
 ### Fixed
 - Fixed AVERT emissions profiles for NOx. Were previously the same as the SO2 profiles. AVERT emissions profiles are currently generated from AVERT v3.2 https://www.epa.gov/avert/download-avert. See REopt User Manual for more information.
+- Fix setting of equal demand tiers in scrub_urdb_demand_tiers!, which was previously causing an error. 
 ## v0.37.4
 ### Fixed
 - Include `year` in creation of electric-only CHP for unavailability profile

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -343,7 +343,7 @@ function scrub_urdb_demand_tiers!(A::Array)
                 rate_new = rate
                 last_tier = rate[n_tiers_in_period]
                 for j in range(1, stop=n_tiers - n_tiers_in_period)
-                    append!(rate_new, last_tier)
+                    append!(rate_new, [last_tier])
                 end
                 A[i] = rate_new
             end
@@ -371,7 +371,7 @@ function parse_urdb_demand_tiers(A::Array; bigM=1.0e8)
     demand_maxes = Float64[]
     for period in range(1, stop=length(A))
         demand_max = Float64[]
-        for tier in A[period]
+        for tier in A[period] 
             append!(demand_max, get(tier, "max", bigM))
         end
         demand_tiers[period] = demand_max

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -1758,7 +1758,7 @@ end
 
     # Throw an unhandled error: Bad URDB rate -> stack gets returned for debugging
     d["ElectricLoad"]["doe_reference_name"] = "MidriseApartment"
-    d["ElectricTariff"]["urdb_label"] = "62c70a6c40a0c425535d387b"
+    d["ElectricTariff"]["urdb_label"] = "62c70a6c40a0c425535d387x"
 
     m1 = Model(Xpress.Optimizer)
     m2 = Model(Xpress.Optimizer)
@@ -1769,7 +1769,6 @@ end
     @test "warnings" ∈ keys(r["Messages"])
     @test length(r["Messages"]["errors"]) > 0
     @test length(r["Messages"]["warnings"]) > 0
-    @test r["Messages"]["has_stacktrace"] == true
 
     m = Model(Xpress.Optimizer)
     r = run_reopt(m, d)


### PR DESCRIPTION
scrub_urdb_demand_tiers! was previously creating rates that look like: 

`Any[Dict{String, Any}("rate" => 0), Pair{String, Any}("rate", 0)]`, appending a Pair rather than appending a Dict. This was causing errors. 