### PR TITLE
Fix CHP standby charges, remove type for const urdb_api_key

### DIFF
--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -268,7 +268,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
             m[:TotalPerUnitHourOMCosts] += m[:TotalHourlyCHPOMCosts]
 
 			if p.s.chp.standby_rate_per_kw_per_month > 1.0e-7
-				m[:TotalCHPStandbyCharges] += sum(p.s.financial.pwf_e * 12 * p.s.chp.standby_rate_per_kw_per_month * m[:dvSize][t] for t in p.techs.chp)
+				m[:TotalCHPStandbyCharges] += sum(p.pwf_e * 12 * p.s.chp.standby_rate_per_kw_per_month * m[:dvSize][t] for t in p.techs.chp)
 			end
 
 			m[:TotalTechCapCosts] += sum(p.s.chp.supplementary_firing_capital_cost_per_kw * m[:dvSupplementaryFiringSize][t] for t in p.techs.chp)

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -3,7 +3,7 @@
 # 5d2360465457a3f77ddc131e has TOU demand
 # 59bc22705457a3372642da67 has monthly tiered demand (no TOU demand)
 
-const urdb_api_key::String = get(ENV, "URDB_API_KEY", "2qt5uihpKXdywTj3uMIhBewxY9K4eNjpRje1JUPL")
+const urdb_api_key = get(ENV, "URDB_API_KEY", "2qt5uihpKXdywTj3uMIhBewxY9K4eNjpRje1JUPL")
 
 """
     Base.@kwdef struct URDBrate


### PR DESCRIPTION
- Fixed wrong object reference for pwf_e in the CHP standby charge constraint
- Removed the type declaration for the const (global) urdb_api_key which is not compatible with Julia version <= 1.7
