### PR TITLE
Add execute permissions to ssc.dll for Wind on Windows

### DIFF
--- a/src/core/production_factor.jl
+++ b/src/core/production_factor.jl
@@ -139,6 +139,7 @@ function get_production_factor(wind::Wind, latitude::Real, longitude::Real, time
         end
 
         global hdl = joinpath(@__DIR__, "..", "sam", libfile)
+        chmod(hdl, filemode(hdl) | 0o755)
         wind_module = @ccall hdl.ssc_module_create("windpower"::Cstring)::Ptr{Cvoid}
         wind_resource = @ccall hdl.ssc_data_create()::Ptr{Cvoid}  # data pointer
         @ccall hdl.ssc_module_exec_set_print(0::Cint)::Cvoid


### PR DESCRIPTION
This fixes an issue with running Wind in REopt.jl on Windows - the SAM ssc.dll file does not have execute permissions on Windows by default, so this line of code ensures that it does.