### PR TITLE
Correct the reported Financial.lcc 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Classify the change according to the following categories:
 
 ## Develop 2024-01-03
 ### Fixed
-- Removed SOC incentive from the report **Financial.lcc** value. 
+- Removed SOC and unserved load incentives from the report **Financial.lcc** value. These were relative small values compared to the LCC but could be large in magnitude for big systems. 
   
 ## Develop 2023-12-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## Develop 2024-01-03
+### Fixed
+- Removed SOC incentive from the report **Financial.lcc** value. 
+  
 ## Develop 2023-12-16
 ### Changed
 - Changed testing suite from using Xpress to using HiGHS, an open-source solver.  This has led to a reduction in the number of tests due to incompatibility with indicator constraints.

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -247,7 +247,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
     m[:GHPOMCosts] = 0.0
 	m[:AvoidedCapexByGHP] = 0.0
 	m[:ResidualGHXCapCost] = 0.0
-	m[:dvHighSOCIncentive] = 0.0
+	m[:dvSOCIncentive] = 0.0
 	m[:dvMinUnservedLoadIncentive] = 0.0
 
 	if !isempty(p.techs.all)
@@ -479,10 +479,10 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 	# Modify objective with small incentives for SOC and unserved load
 	if !(isempty(p.s.storage.types.elec)) && p.s.settings.add_soc_incentive
 		# Incentive to keep SOC high
-		m[:dvHighSOCIncentive] = sum(
+		m[:dvSOCIncentive] = sum(
 								m[:dvStoredEnergy][b, ts] for b in p.s.storage.types.elec, ts in p.time_steps
 							) / (8760. / p.hours_per_time_step)
-		add_to_expression!(Objective, - m[:dvHighSOCIncentive])
+		add_to_expression!(Objective, - m[:dvSOCIncentive])
 	end
 	if !isempty(p.s.electric_utility.outage_durations)
 		# Incentive to minimize unserved load in each outage, not just the max over outage start times

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -492,14 +492,6 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 
 	@objective(m, Min, m[:Objective])
 	
-	# if !(isempty(p.s.storage.types.elec)) && p.s.settings.add_soc_incentive # Keep SOC high
-	# 	@objective(m, Min, m[:Costs] - 
-	# 	sum(m[:dvStoredEnergy][b, ts] for b in p.s.storage.types.elec, ts in p.time_steps) /
-	# 		(8760. / p.hours_per_time_step)
-	# 	)
-	
-	# end
-
 	for b in p.s.storage.types.elec
 		if p.s.storage.attr[b].model_degradation
 			add_degradation(m, p; b=b)

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -54,7 +54,9 @@ function add_financial_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _
         m[Symbol("GHPCapCosts"*_n)] = 0.0
     end
 
-    r["lcc"] = value(m[Symbol("Costs"*_n)]) + 0.0001 * value(m[Symbol("MinChargeAdder"*_n)]) - value(m[Symbol("dvComfortLimitViolationCost"*_n)])
+    r["lcc"] = (value(m[Symbol("Costs"*_n)]) + 0.0001 * value(m[Symbol("MinChargeAdder"*_n)]) - value(m[Symbol("dvComfortLimitViolationCost"*_n)]) 
+    + value(m[Symbol("dvHighSOCIncentive"*_n)]))
+
     r["lifecycle_om_costs_before_tax"] = value(m[Symbol("TotalPerUnitSizeOMCosts"*_n)] + 
                                            m[Symbol("TotalPerUnitProdOMCosts"*_n)] + m[Symbol("TotalPerUnitHourOMCosts"*_n)] + m[Symbol("GHPOMCosts"*_n)])
     

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -47,6 +47,9 @@ function add_financial_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _
     if !(Symbol("TotalPerUnitHourOMCosts"*_n) in keys(m.obj_dict)) # CHP not currently included in multi-node modeling  
         m[Symbol("TotalPerUnitHourOMCosts"*_n)] = 0.0
     end
+    if !(Symbol("dvMinUnservedLoadIncentive"*_n) in keys(m.obj_dict)) # Multiple outages not in in multi-node modeling
+        m[Symbol("dvMinUnservedLoadIncentive"*_n)] = 0.0
+    end
     if !(Symbol("GHPOMCosts"*_n) in keys(m.obj_dict)) # CHP not currently included in multi-node modeling  
         m[Symbol("GHPOMCosts"*_n)] = 0.0
     end

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -55,7 +55,7 @@ function add_financial_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _
     end
 
     r["lcc"] = (value(m[Symbol("Costs"*_n)]) + 0.0001 * value(m[Symbol("MinChargeAdder"*_n)]) - value(m[Symbol("dvComfortLimitViolationCost"*_n)]) 
-    + value(m[Symbol("dvHighSOCIncentive"*_n)]))
+                + value(m[Symbol("dvHighSOCIncentive"*_n)]) - value(m[:dvMinUnservedLoadIncentive]))
 
     r["lifecycle_om_costs_before_tax"] = value(m[Symbol("TotalPerUnitSizeOMCosts"*_n)] + 
                                            m[Symbol("TotalPerUnitProdOMCosts"*_n)] + m[Symbol("TotalPerUnitHourOMCosts"*_n)] + m[Symbol("GHPOMCosts"*_n)])

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -55,7 +55,7 @@ function add_financial_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _
     end
 
     r["lcc"] = (value(m[Symbol("Costs"*_n)]) + 0.0001 * value(m[Symbol("MinChargeAdder"*_n)]) - value(m[Symbol("dvComfortLimitViolationCost"*_n)]) 
-                + value(m[Symbol("dvHighSOCIncentive"*_n)]) - value(m[:dvMinUnservedLoadIncentive]))
+                + value(m[Symbol("dvSOCIncentive"*_n)]) - value(m[Symbol("dvMinUnservedLoadIncentive"*_n)]))
 
     r["lifecycle_om_costs_before_tax"] = value(m[Symbol("TotalPerUnitSizeOMCosts"*_n)] + 
                                            m[Symbol("TotalPerUnitProdOMCosts"*_n)] + m[Symbol("TotalPerUnitHourOMCosts"*_n)] + m[Symbol("GHPOMCosts"*_n)])


### PR DESCRIPTION
The `Financial.lcc` reported in the results previously included the small battery SOC and unserved load incentives that were added to the objective in `reopt.jl`. 

I think it had been assumed that using `add_to_expression!(Objective, value)` would not modify `m[:Costs]`, but in fact it was modifying it to include these incentive values. 