### PR TITLE
Limit battery storage duration v2

### DIFF
--- a/src/constraints/storage_constraints.jl
+++ b/src/constraints/storage_constraints.jl
@@ -21,6 +21,11 @@ function add_storage_size_constraints(m, p, b; _n="")
 	@constraint(m,
         m[Symbol("dvStoragePower"*_n)][b] <= p.s.storage.attr[b].max_kw
     )
+
+    # Constraint (4c)-3: Limit on Storage Energy Capacity based on Maximum Duration Hours
+	@constraint(m,
+        m[Symbol("dvStorageEnergy"*_n)][b] <= m[Symbol("dvStoragePower"*_n)][b] * p.s.storage.attr[b].max_duration_hours
+    )
 end
 
 

--- a/src/core/energy_storage/electric_storage.jl
+++ b/src/core/energy_storage/electric_storage.jl
@@ -164,6 +164,7 @@ end
     model_degradation::Bool = false
     degradation::Dict = Dict()
     minimum_avg_soc_fraction::Float64 = 0.0
+    max_duration_hours::Real = 40.0 # Maximum amount of time storage can discharge at its rated power capacity (ratio of ElectricStorage size_kwh to size_kw)
 ```
 """
 Base.@kwdef struct ElectricStorageDefaults
@@ -196,6 +197,7 @@ Base.@kwdef struct ElectricStorageDefaults
     model_degradation::Bool = false
     degradation::Dict = Dict()
     minimum_avg_soc_fraction::Float64 = 0.0
+    max_duration_hours::Real = 40.0
 end
 
 
@@ -236,6 +238,7 @@ struct ElectricStorage <: AbstractElectricStorage
     model_degradation::Bool
     degradation::Degradation
     minimum_avg_soc_fraction::Float64
+    max_duration_hours::Real
 
     function ElectricStorage(d::Dict, f::Financial)  
         s = ElectricStorageDefaults(;d...)
@@ -322,7 +325,8 @@ struct ElectricStorage <: AbstractElectricStorage
             net_present_cost_per_kwh,
             s.model_degradation,
             degr,
-            s.minimum_avg_soc_fraction
+            s.minimum_avg_soc_fraction,
+            s.max_duration_hours
         )
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,7 +297,8 @@ else  # run HiGHS tests
                     "min_kwh" => 400000,
                     "max_kwh" => 400000,
                     "soc_min_fraction" => 0.8,
-                    "soc_init_fraction" => 0.9
+                    "soc_init_fraction" => 0.9,
+                    "max_duration_hours" => 100
                 ),
                 "ElectricLoad" => Dict(
                     "doe_reference_name" => "FlatLoad",


### PR DESCRIPTION
Duplicating changes made by @atpham88 in #332 so that branch name doesn't have "_".

## Summary
This PR adds user-input option to limit the hour duration for battery storage.

## Implementation notes
Changes in this PR to add this option:

1. electric_storage.jl: added a battery_hour input, default is 30. This default can be changed in ["ElectricStorage"]["max_duration_hours"]. For ex:

```
input["ElectricStorage"]["max_duration_hours"] = 8
```
2. storage_constraints.jl: Add a constraint to limit battery energy capacity = battery power rating * max_duration_hours.
https://github.com/NREL/REopt.jl/blob/limit_battery_energy_cap/src/constraints/storage_constraints.jl#L26
