### PR TITLE
Fix BAU emissions calc with boiler heating load

### DIFF
--- a/src/core/bau_inputs.jl
+++ b/src/core/bau_inputs.jl
@@ -255,7 +255,10 @@ function setup_bau_emissions_inputs(p::REoptInputs, s_bau::BAUScenario, generato
     ## Boiler emissions
     if "ExistingBoiler" in p.techs.all
         for heat_type in ["space_heating", "dhw"]
-            bau_emissions_lb_CO2_per_year += getproperty(p.s,Symbol("$(heat_type)_load")).annual_mmbtu * p.s.existing_boiler.emissions_factor_lb_CO2_per_mmbtu
+            # Divide by existing_boiler.efficiency because annual_mmbtu is thermal, so convert to fuel
+            bau_emissions_lb_CO2_per_year += getproperty(p.s,Symbol("$(heat_type)_load")).annual_mmbtu / 
+                                                p.s.existing_boiler.efficiency * 
+                                                p.s.existing_boiler.emissions_factor_lb_CO2_per_mmbtu
         end
     end
 


### PR DESCRIPTION
This fixes an issue with BAU emissions being calculated based on BAU **thermal** load instead of **fuel**.