### PR TITLE
Solver-specific workarounds for Big-M Constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## Develop 2024-03-26
+### Added 
+- in `src/settings.jl`, added new const **INDICATOR_COMPATIBLE_SOLVERS**
+- in `src/settings.jl`, added new member **solver_name** within the settings object.  This is currently not connected to the solver but does determine whether indicator constraints are modeled or if their big-M workarounds are used.
+- added replacements for indicator constraints with the exception of battery degradation, which is implemented in a separate model, and FlexibleHVAC.  TODO's have been added for these remaining cases.
+
+### Fixed
+- Fixed previously broken tests using HiGHS in `test/runtests.jl` due to solver incompatibility.
+
 ## v0.43.0
 ### Fixed
 - `simple_payback_years` calculation when there is export credit

--- a/src/REopt.jl
+++ b/src/REopt.jl
@@ -103,6 +103,7 @@ const EMISSIONS_DECREASE_DEFAULTS = Dict(
     "SO2" => 0.02163,
     "PM25" => 0.02163
 )
+const INDICATOR_COMPATIBLE_SOLVERS = ["Cbc","CPLEX","Xpress","SCIP"]
 
 include("logging.jl")
 

--- a/src/constraints/battery_degradation.jl
+++ b/src/constraints/battery_degradation.jl
@@ -106,6 +106,7 @@ function add_degradation(m, p; b="ElectricStorage")
         @warn "Adding binary and indicator constraints for 
          ElectricStorage.degradation.maintenance_strategy = \"replacement\". 
          Not all solvers support indicators and some are slow with integers."
+        # TODO import the latest battery degradation model in the degradation branch
         @variable(m, soh_indicator[days], Bin)
         @constraint(m, [d in days],
             soh_indicator[d] => {SOH[d] >= 0.8*m[:dvStorageEnergy][b]}

--- a/src/constraints/battery_degradation.jl
+++ b/src/constraints/battery_degradation.jl
@@ -107,7 +107,7 @@ function add_degradation(m, p; b="ElectricStorage")
          ElectricStorage.degradation.maintenance_strategy = \"replacement\". 
          Not all solvers support indicators and some are slow with integers."
         @variable(m, soh_indicator[days], Bin)
-        if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+        if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
             @constraint(m, [d in days],
                 soh_indicator[d] => {SOH[d] >= 0.8*m[:dvStorageEnergy][b]}
             )

--- a/src/constraints/battery_degradation.jl
+++ b/src/constraints/battery_degradation.jl
@@ -107,15 +107,9 @@ function add_degradation(m, p; b="ElectricStorage")
          ElectricStorage.degradation.maintenance_strategy = \"replacement\". 
          Not all solvers support indicators and some are slow with integers."
         @variable(m, soh_indicator[days], Bin)
-        if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
-            @constraint(m, [d in days],
-                soh_indicator[d] => {SOH[d] >= 0.8*m[:dvStorageEnergy][b]}
-            )
-        else
-            @constraint(m, [d in days],
-                SOH[d] >= 0.8*m[:dvStorageEnergy][b] - soh_indicator[d]*p.s.storage.attr[b].max_kwh
-            )
-        end
+        @constraint(m, [d in days],
+            soh_indicator[d] => {SOH[d] >= 0.8*m[:dvStorageEnergy][b]}
+        )
         @expression(m, d_0p8, sum(soh_indicator[d] for d in days))
 
         # define binaries for the finding the month that battery must be replaced

--- a/src/constraints/chp_constraints.jl
+++ b/src/constraints/chp_constraints.jl
@@ -100,7 +100,7 @@ function add_chp_supplementary_firing_constraints(m, p; _n="")
                 m[Symbol("dvSupplementaryThermalProduction"*_n)][t,ts] <=
                 (p.s.chp.supplementary_firing_max_steam_ratio - 1.0) * p.production_factor[t,ts] * (thermal_prod_slope * m[Symbol("dvSupplementaryFiringSize"*_n)][t] + m[Symbol("dvThermalProductionYIntercept"*_n)][t,ts])
                 )
-    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+    if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
         # Constrain lower limit of 0 if CHP tech is off
         @constraint(m, NoCHPSupplementaryFireOffCon[t in p.techs.chp, ts in p.time_steps],
                 !m[Symbol("binCHPIsOnInTS"*_n)][t,ts] => {m[Symbol("dvSupplementaryThermalProduction"*_n)][t,ts] <= 0.0}

--- a/src/constraints/chp_constraints.jl
+++ b/src/constraints/chp_constraints.jl
@@ -100,10 +100,18 @@ function add_chp_supplementary_firing_constraints(m, p; _n="")
                 m[Symbol("dvSupplementaryThermalProduction"*_n)][t,ts] <=
                 (p.s.chp.supplementary_firing_max_steam_ratio - 1.0) * p.production_factor[t,ts] * (thermal_prod_slope * m[Symbol("dvSupplementaryFiringSize"*_n)][t] + m[Symbol("dvThermalProductionYIntercept"*_n)][t,ts])
                 )
-    # Constrain lower limit of 0 if CHP tech is off
-    @constraint(m, NoCHPSupplementaryFireOffCon[t in p.techs.chp, ts in p.time_steps],
+    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+        # Constrain lower limit of 0 if CHP tech is off
+        @constraint(m, NoCHPSupplementaryFireOffCon[t in p.techs.chp, ts in p.time_steps],
                 !m[Symbol("binCHPIsOnInTS"*_n)][t,ts] => {m[Symbol("dvSupplementaryThermalProduction"*_n)][t,ts] <= 0.0}
                 )
+    else
+        #There's no upper bound specified for the CHP supplementary firing, so assume the entire heat load as a reasonable maximum that wouldn't be exceeded (but might not be the best possible value). 
+        max_supplementary_firing_size = maximum(p.s.dhw_load.loads_kw .+ p.s.space_heating_load.loads_kw)
+        @constraint(m, NoCHPSupplementaryFireOffCon[t in p.techs.chp, ts in p.time_steps],
+                m[Symbol("dvSupplementaryThermalProduction"*_n)][t,ts] <= (p.s.chp.supplementary_firing_max_steam_ratio - 1.0) * p.production_factor[t,ts] * (thermal_prod_slope * max_supplementary_firing_size + m[Symbol("dvThermalProductionYIntercept"*_n)][t,ts])
+                )
+    end
 end
 
 function add_binCHPIsOnInTS_constraints(m, p; _n="")

--- a/src/constraints/electric_utility_constraints.jl
+++ b/src/constraints/electric_utility_constraints.jl
@@ -57,7 +57,7 @@ function add_export_constraints(m, p; _n="")
 
             
             # If choosing to take advantage of NEM, must have total capacity less than net_metering_limit_kw
-            if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+            if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
                 @constraint(m,
                     binNEM => {sum(m[Symbol("dvSize"*_n)][t] for t in NEM_techs) <= p.s.electric_utility.net_metering_limit_kw}
                 )
@@ -71,7 +71,7 @@ function add_export_constraints(m, p; _n="")
             end
 
             # binary choice for NEM benefit
-            if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+            if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
                 @constraint(m,
                     binNEM => {NEM_benefit >= p.pwf_e * p.hours_per_time_step *
                         sum( sum(p.s.electric_tariff.export_rates[:NEM][ts] * m[Symbol("dvProductionToGrid"*_n)][t, :NEM, ts] 
@@ -91,7 +91,7 @@ function add_export_constraints(m, p; _n="")
             EXC_benefit = 0
             if :EXC in p.s.electric_tariff.export_bins
                 EXC_benefit = @variable(m, lower_bound = max_bene)
-                if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+                if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
                     @constraint(m,
                         binNEM => {EXC_benefit >= p.pwf_e * p.hours_per_time_step *
                             sum( sum(p.s.electric_tariff.export_rates[:EXC][ts] * m[Symbol("dvProductionToGrid"*_n)][t, :EXC, ts] 
@@ -126,7 +126,7 @@ function add_export_constraints(m, p; _n="")
             WHL_benefit = @variable(m, lower_bound = max_bene)
 
             @constraint(m, binNEM + binWHL == 1)  # can either NEM or WHL export, not both
-            if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+            if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
                 @constraint(m,
                     binWHL => {WHL_benefit >= p.pwf_e * p.hours_per_time_step *
                         sum( sum(p.s.electric_tariff.export_rates[:WHL][ts] * m[Symbol("dvProductionToGrid"*_n)][t, :WHL, ts] 

--- a/src/constraints/electric_utility_constraints.jl
+++ b/src/constraints/electric_utility_constraints.jl
@@ -266,7 +266,7 @@ function add_simultaneous_export_import_constraint(m, p; _n="")
             sum(m[Symbol("dvGridToStorage"*_n)][b, ts] for b in p.s.storage.types.elec) <= bigM_hourly_load*(1-m[Symbol("binNoGridPurchases"*_n)][ts])
         )
         @constraint(m, ExportOnlyAfterSiteLoadMetCon[ts in p.time_steps],
-            sum(m[Symbol("dvProductionToGrid"*_n)][t,u,ts] for t in p.techs.elec, u in p.export_bins_by_tech[t]) <= bigM_hourly_load * (1-m[Symbol("binNoGridPurchases"*_n)][ts])
+            sum(m[Symbol("dvProductionToGrid"*_n)][t,u,ts] for t in p.techs.elec, u in p.export_bins_by_tech[t]) <= bigM_hourly_load * m[Symbol("binNoGridPurchases"*_n)][ts]
         )
     end
 end

--- a/src/constraints/electric_utility_constraints.jl
+++ b/src/constraints/electric_utility_constraints.jl
@@ -247,17 +247,28 @@ end
 
 
 function add_simultaneous_export_import_constraint(m, p; _n="")
-    @constraint(m, NoGridPurchasesBinary[ts in p.time_steps],
-        m[Symbol("binNoGridPurchases"*_n)][ts] => {
-          sum(m[Symbol("dvGridPurchase"*_n)][ts, tier] for tier in 1:p.s.electric_tariff.n_energy_tiers) +
-          sum(m[Symbol("dvGridToStorage"*_n)][b, ts] for b in p.s.storage.types.elec) <= 0
-        }
-    )
-    @constraint(m, ExportOnlyAfterSiteLoadMetCon[ts in p.time_steps],
-        !m[Symbol("binNoGridPurchases"*_n)][ts] => {
-            sum(m[Symbol("dvProductionToGrid"*_n)][t,u,ts] for t in p.techs.elec, u in p.export_bins_by_tech[t]) <= 0
-        }
-    )
+    if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
+        @constraint(m, NoGridPurchasesBinary[ts in p.time_steps],
+            m[Symbol("binNoGridPurchases"*_n)][ts] => {
+                sum(m[Symbol("dvGridPurchase"*_n)][ts, tier] for tier in 1:p.s.electric_tariff.n_energy_tiers) +
+                sum(m[Symbol("dvGridToStorage"*_n)][b, ts] for b in p.s.storage.types.elec) <= 0
+            }
+        )
+        @constraint(m, ExportOnlyAfterSiteLoadMetCon[ts in p.time_steps],
+            !m[Symbol("binNoGridPurchases"*_n)][ts] => {
+                sum(m[Symbol("dvProductionToGrid"*_n)][t,u,ts] for t in p.techs.elec, u in p.export_bins_by_tech[t]) <= 0
+            }
+        )
+    else
+        bigM_hourly_load = maximum(p.s.electric_load.loads_kw)+maximum(p.s.space_heating_load.loads_kw)+maximum(p.s.dhw_load.loads_kw)+maximum(p.s.cooling_load.loads_kw_thermal)
+        @constraint(m, NoGridPurchasesBinary[ts in p.time_steps],
+            sum(m[Symbol("dvGridPurchase"*_n)][ts, tier] for tier in 1:p.s.electric_tariff.n_energy_tiers) +
+            sum(m[Symbol("dvGridToStorage"*_n)][b, ts] for b in p.s.storage.types.elec) <= bigM_hourly_load*(1-m[Symbol("binNoGridPurchases"*_n)][ts])
+        )
+        @constraint(m, ExportOnlyAfterSiteLoadMetCon[ts in p.time_steps],
+            sum(m[Symbol("dvProductionToGrid"*_n)][t,u,ts] for t in p.techs.elec, u in p.export_bins_by_tech[t]) <= bigM_hourly_load * (1-m[Symbol("binNoGridPurchases"*_n)][ts])
+        )
+    end
 end
 
 

--- a/src/constraints/flexible_hvac.jl
+++ b/src/constraints/flexible_hvac.jl
@@ -16,6 +16,7 @@ function add_flexible_hvac_constraints(m, p::REoptInputs; _n="")
 
     if !isempty(p.techs.heating) && !isempty(p.techs.cooling)
         # space temperature evolution based on state-space model
+        # TODO: Add indicator constraint workaround for FlexibleHVAC
         @constraint(m, [n in 1:N, ts in 2:length(p.time_steps)],
             binFlexHVAC => { dvTemperature[n, ts] == dvTemperature[n, ts-1] + 
                 sum(p.s.flexible_hvac.system_matrix[n, i] * dvTemperature[i, ts-1] for i=1:N) + 

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -56,12 +56,20 @@ end
 
 
 function add_MG_size_constraints(m,p)
+    # @constraint(m, [t in p.techs.elec],
+    #     m[:binMGTechUsed][t] => {m[:dvMGsize][t] >= 1.0}  # 1 kW min size to prevent binaryMGTechUsed = 1 with zero cost
+    # )
+
+    # @constraint(m, [b in p.s.storage.types.all],
+    #     m[:binMGStorageUsed] => {m[:dvStoragePower][b] >= 1.0} # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
+    # )
+
     @constraint(m, [t in p.techs.elec],
-        m[:binMGTechUsed][t] => {m[:dvMGsize][t] >= 1.0}  # 1 kW min size to prevent binaryMGTechUsed = 1 with zero cost
+         m[:dvMGsize][t] >= m[:binMGTechUsed][t]  # 1 kW min size to prevent binaryMGTechUsed = 1 with zero cost
     )
 
     @constraint(m, [b in p.s.storage.types.all],
-        m[:binMGStorageUsed] => {m[:dvStoragePower][b] >= 1.0} # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
+        m[:dvStoragePower][b] >= m[:binMGStorageUsed] # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
     )
     
     if p.s.site.mg_tech_sizes_equal_grid_sizes

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -30,7 +30,7 @@ function add_outage_cost_constraints(m,p)
     )
    
     if !isempty(setdiff(p.techs.elec, p.techs.segmented))
-        if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+        if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
             @constraint(m, [t in setdiff(p.techs.elec, p.techs.segmented)],
                 m[:binMGTechUsed][t] => {m[:dvMGTechUpgradeCost][t] >= p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor *
                                         p.cap_cost_slope[t] * m[:dvMGsize][t]}
@@ -51,7 +51,7 @@ function add_outage_cost_constraints(m,p)
 
     if !isempty(p.techs.segmented)
         @warn "Adding binary variable(s) to model cost curves in stochastic outages"
-        if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+        if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
             @constraint(m, [t in p.techs.segmented],  # cannot have this for statement in sum( ... for t in ...) ???
                 m[:binMGTechUsed][t] => {m[:dvMGTechUpgradeCost][t] >= p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor * 
                     sum(p.cap_cost_slope[t][s] * m[Symbol("dvSegmentSystemSize"*t)][s] + 
@@ -68,7 +68,7 @@ function add_outage_cost_constraints(m,p)
         end
     end
 
-    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+    if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
         @constraint(m,
             m[:binMGStorageUsed] => {m[:dvMGStorageUpgradeCost] >= p.s.financial.microgrid_upgrade_cost_fraction * m[:TotalStorageCapCosts]}
         )
@@ -231,7 +231,7 @@ end
 function add_binMGGenIsOnInTS_constraints(m,p)
     # The following 2 constraints define binMGGenIsOnInTS to be the binary corollary to dvMGRatedProd for generator,
     # i.e. binMGGenIsOnInTS = 1 for dvMGRatedProd > min_turn_down_fraction * dvMGsize, and binMGGenIsOnInTS = 0 for dvMGRatedProd = 0
-    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+    if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
         @constraint(m, [t in p.techs.gen, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
             !m[:binMGGenIsOnInTS][s, tz, ts] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
         )
@@ -257,7 +257,7 @@ end
 function add_binMGCHPIsOnInTS_constraints(m, p; _n="")
     # The following 2 constraints define binMGCHPIsOnInTS to be the binary corollary to dvMGRatedProd for CHP,
     # i.e. binMGCHPIsOnInTS = 1 for dvMGRatedProd > min_turn_down_fraction * dvMGsize, and binMGCHPIsOnInTS = 0 for dvMGRatedProd = 0
-    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+    if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
         @constraint(m, [t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
             !m[:binMGCHPIsOnInTS][s, tz, ts] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
         )
@@ -314,7 +314,7 @@ function add_MG_storage_dispatch_constraints(m,p)
         m[:dvStorageEnergy]["ElectricStorage"] >= m[:dvMGStoredEnergy][s, tz, ts]
     )
     
-    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+    if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
         @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
             !m[:binMGStorageUsed] => { sum(m[:dvMGProductionToStorage][t, s, tz, ts] for t in p.techs.elec) <= 0 }
         )
@@ -356,7 +356,7 @@ function add_cannot_have_MG_with_only_PVwind_constraints(m, p)
     renewable_techs = setdiff(p.techs.elec, dispatchable_techs)
     # can't "turn down" renewable_techs
     if !isempty(renewable_techs)
-        if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+        if p.s.settings.solver_name in INDICATOR_COMPATIBLE_SOLVERS
             @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
                 m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] >= m[:dvMGsize][t] }
             )

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -30,24 +30,59 @@ function add_outage_cost_constraints(m,p)
     )
    
     if !isempty(setdiff(p.techs.elec, p.techs.segmented))
-        @constraint(m, [t in setdiff(p.techs.elec, p.techs.segmented)],
-            m[:binMGTechUsed][t] => {m[:dvMGTechUpgradeCost][t] >= p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor *
-                                    p.cap_cost_slope[t] * m[:dvMGsize][t]}
-        )
+        if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+            @constraint(m, [t in setdiff(p.techs.elec, p.techs.segmented)],
+                m[:binMGTechUsed][t] => {m[:dvMGTechUpgradeCost][t] >= p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor *
+                                        p.cap_cost_slope[t] * m[:dvMGsize][t]}
+            )
+        else
+            @constraint(m, [t in setdiff(p.techs.elec, p.techs.segmented)],
+                m[:dvMGTechUpgradeCost][t] >= p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor *
+                                        p.cap_cost_slope[t] * m[:dvMGsize][t] - (
+                                            p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor *
+                                            p.cap_cost_slope[t] * p.max_sizes[t] * (1-m[:binMGTechUsed][t])
+                                        )  #TODO: check max_sizes for quality of lower bounds (can we make a better big-M?)
+            )
+            @constraint(m, [t in setdiff(p.techs.elec, p.techs.segmented)],
+                m[:dvMGTechUpgradeCost][t] >= 0.0
+            )
+        end
     end
 
     if !isempty(p.techs.segmented)
         @warn "Adding binary variable(s) to model cost curves in stochastic outages"
-        @constraint(m, [t in p.techs.segmented],  # cannot have this for statement in sum( ... for t in ...) ???
-            m[:binMGTechUsed][t] => {m[:dvMGTechUpgradeCost][t] >= p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor * 
-                sum(p.cap_cost_slope[t][s] * m[Symbol("dvSegmentSystemSize"*t)][s] + 
-                    p.seg_yint[t][s] * m[Symbol("binSegment"*t)][s] for s in 1:p.n_segs_by_tech[t])}
-            )
+        if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+            @constraint(m, [t in p.techs.segmented],  # cannot have this for statement in sum( ... for t in ...) ???
+                m[:binMGTechUsed][t] => {m[:dvMGTechUpgradeCost][t] >= p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor * 
+                    sum(p.cap_cost_slope[t][s] * m[Symbol("dvSegmentSystemSize"*t)][s] + 
+                        p.seg_yint[t][s] * m[Symbol("binSegment"*t)][s] for s in 1:p.n_segs_by_tech[t])}
+                )
+        else
+            @constraint(m, [t in p.techs.segmented],  
+                m[:dvMGTechUpgradeCost][t] >= p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor * 
+                    sum(p.cap_cost_slope[t][s] * m[Symbol("dvSegmentSystemSize"*t)][s] + 
+                        p.seg_yint[t][s] * m[Symbol("binSegment"*t)][s] for s in 1:p.n_segs_by_tech[t]) -
+                        (maximum(p.cap_cost_slope[t][:])*p.max_sizes[t]+maximum(p.seg_yint[t][:]))*(1-m[:binMGTechUsed][t])
+                )
+            @constraint(m, [t in p.techs.segmented], m[:dvMGTechUpgradeCost][t] >= 0.0)
+        end
     end
 
-    @constraint(m,
-        m[:binMGStorageUsed] => {m[:dvMGStorageUpgradeCost] >= p.s.financial.microgrid_upgrade_cost_fraction * m[:TotalStorageCapCosts]}
-    )
+    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+        @constraint(m,
+            m[:binMGStorageUsed] => {m[:dvMGStorageUpgradeCost] >= p.s.financial.microgrid_upgrade_cost_fraction * m[:TotalStorageCapCosts]}
+        )
+    else
+        @constraint(m,
+            m[:dvMGStorageUpgradeCost] >= p.s.financial.microgrid_upgrade_cost_fraction * m[:TotalStorageCapCosts] - (
+                p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor * (
+                    sum( p.s.storage.attr[b].net_present_cost_per_kw * p.s.storage.attr[b].max_kw for b in p.s.storage.types.elec) + 
+                    sum( p.s.storage.attr[b].net_present_cost_per_kwh * p.s.storage.attr[b].max_kwh for b in p.s.storage.types.all )
+                ) * (1-m[:binMGStorageUsed])  # Big-M is capital cost of battery with max size kw and kwh
+            )
+        )
+        @constraint(m, m[:dvMGStorageUpgradeCost] >= 0.0)
+    end
     
     @expression(m, mgTotalTechUpgradeCost,
         sum( m[:dvMGTechUpgradeCost][t] for t in p.techs.elec )
@@ -56,14 +91,6 @@ end
 
 
 function add_MG_size_constraints(m,p)
-    # @constraint(m, [t in p.techs.elec],
-    #     m[:binMGTechUsed][t] => {m[:dvMGsize][t] >= 1.0}  # 1 kW min size to prevent binaryMGTechUsed = 1 with zero cost
-    # )
-
-    # @constraint(m, [b in p.s.storage.types.all],
-    #     m[:binMGStorageUsed] => {m[:dvStoragePower][b] >= 1.0} # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
-    # )
-
     @constraint(m, [t in p.techs.elec],
          m[:dvMGsize][t] >= m[:binMGTechUsed][t]  # 1 kW min size to prevent binaryMGTechUsed = 1 with zero cost
     )
@@ -204,14 +231,23 @@ end
 function add_binMGGenIsOnInTS_constraints(m,p)
     # The following 2 constraints define binMGGenIsOnInTS to be the binary corollary to dvMGRatedProd for generator,
     # i.e. binMGGenIsOnInTS = 1 for dvMGRatedProd > min_turn_down_fraction * dvMGsize, and binMGGenIsOnInTS = 0 for dvMGRatedProd = 0
-    @constraint(m, [t in p.techs.gen, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-        !m[:binMGGenIsOnInTS][s, tz, ts] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
-    )
-    @constraint(m, [t in p.techs.gen, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-        m[:binMGGenIsOnInTS][s, tz, ts] => { 
-            m[:dvMGRatedProduction][t, s, tz, ts] >= p.s.generator.min_turn_down_fraction * m[:dvMGsize][t]
-        }
-    )
+    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+        @constraint(m, [t in p.techs.gen, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            !m[:binMGGenIsOnInTS][s, tz, ts] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
+        )
+        @constraint(m, [t in p.techs.gen, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            m[:binMGGenIsOnInTS][s, tz, ts] => { 
+                m[:dvMGRatedProduction][t, s, tz, ts] >= p.s.generator.min_turn_down_fraction * m[:dvMGsize][t]
+            }
+        )
+    else
+        @constraint(m, [t in p.techs.gen, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            m[:dvMGRatedProduction][t, s, tz, ts] <= p.max_sizes[t] *  m[:binMGGenIsOnInTS][s, tz, ts]
+        )
+        @constraint(m, [t in p.techs.gen, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            m[:dvMGRatedProduction][t, s, tz, ts] >= p.s.generator.min_turn_down_fraction * m[:dvMGsize][t] - p.max_sizes[t] * (1-m[:binMGGenIsOnInTS][s, tz, ts])
+        )
+    end
     @constraint(m, [t in p.techs.gen, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
         m[:binMGTechUsed][t] >= m[:binMGGenIsOnInTS][s, tz, ts]
     )
@@ -221,9 +257,15 @@ end
 function add_binMGCHPIsOnInTS_constraints(m, p; _n="")
     # The following 2 constraints define binMGCHPIsOnInTS to be the binary corollary to dvMGRatedProd for CHP,
     # i.e. binMGCHPIsOnInTS = 1 for dvMGRatedProd > min_turn_down_fraction * dvMGsize, and binMGCHPIsOnInTS = 0 for dvMGRatedProd = 0
-    @constraint(m, [t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-        !m[:binMGCHPIsOnInTS][s, tz, ts] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
-    )
+    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+        @constraint(m, [t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            !m[:binMGCHPIsOnInTS][s, tz, ts] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
+        )
+    else
+        @constraint(m, [t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            m[:dvMGRatedProduction][t, s, tz, ts] <= p.max_sizes[t] * m[:binMGCHPIsOnInTS][s, tz, ts] 
+        )
+    end
     @constraint(m, [t in p.techs.chp, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
         m[:binMGTechUsed][t] >= m[:binMGCHPIsOnInTS][s, tz, ts]
     )
@@ -272,13 +314,23 @@ function add_MG_storage_dispatch_constraints(m,p)
         m[:dvStorageEnergy]["ElectricStorage"] >= m[:dvMGStoredEnergy][s, tz, ts]
     )
     
-    @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-        !m[:binMGStorageUsed] => { sum(m[:dvMGProductionToStorage][t, s, tz, ts] for t in p.techs.elec) <= 0 }
-    )
-    
-    @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-        !m[:binMGStorageUsed] => { m[:dvMGDischargeFromStorage][s, tz, ts] <= 0 }
-    )
+    if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
+        @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            !m[:binMGStorageUsed] => { sum(m[:dvMGProductionToStorage][t, s, tz, ts] for t in p.techs.elec) <= 0 }
+        )
+        
+        @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            !m[:binMGStorageUsed] => { m[:dvMGDischargeFromStorage][s, tz, ts] <= 0 }
+        )
+    else
+        @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            sum(m[:dvMGProductionToStorage][t, s, tz, ts] for t in p.techs.elec) <= p.s.storage_attr[b].max_kw * m[:binMGStorageUsed]
+        )
+        
+        @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+            m[:dvMGDischargeFromStorage][s, tz, ts] <= p.s.storage_attr[b].max_kw * m[:binMGStorageUsed]
+        )
+    end
 end
 
 
@@ -304,19 +356,28 @@ function add_cannot_have_MG_with_only_PVwind_constraints(m, p)
     renewable_techs = setdiff(p.techs.elec, dispatchable_techs)
     # can't "turn down" renewable_techs
     if !isempty(renewable_techs)
-        @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-            m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] >= m[:dvMGsize][t] }
-        )
-        @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-            !m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
-        )
-        if !isempty(dispatchable_techs) # PV or Wind alone cannot be used for a MG
+        if p.s.settings.solver_id in INDICATOR_COMPATIBLE_SOLVERS
             @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-                m[:binMGTechUsed][t] => { sum(m[:binMGTechUsed][tek] for tek in dispatchable_techs) + m[:binMGStorageUsed] >= 1 }
+                m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] >= m[:dvMGsize][t] }
+            )
+            @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+                !m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
             )
         else
             @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-                m[:binMGTechUsed][t] => { m[:binMGStorageUsed] >= 1 }
+                m[:dvMGRatedProduction][t, s, tz, ts] >= m[:dvMGsize][t] - p.max_sizes[t] * (1-m[:binMGTechUsed][t])
+            )
+            @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+                m[:dvMGRatedProduction][t, s, tz, ts] <= p.max_sizes[t] * m[:binMGTechUsed][t]
+            )
+        end
+        if !isempty(dispatchable_techs) # PV or Wind alone cannot be used for a MG
+            @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+                sum(m[:binMGTechUsed][tek] for tek in dispatchable_techs) + m[:binMGStorageUsed] >= m[:binMGTechUsed][t]
+            )
+        else
+            @constraint(m, [t in renewable_techs, s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
+                m[:binMGStorageUsed] >= m[:binMGTechUsed][t]
             )
         end
     end

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -62,7 +62,7 @@ function add_outage_cost_constraints(m,p)
                 m[:dvMGTechUpgradeCost][t] >= p.s.financial.microgrid_upgrade_cost_fraction * p.third_party_factor * 
                     sum(p.cap_cost_slope[t][s] * m[Symbol("dvSegmentSystemSize"*t)][s] + 
                         p.seg_yint[t][s] * m[Symbol("binSegment"*t)][s] for s in 1:p.n_segs_by_tech[t]) -
-                        (maximum(p.cap_cost_slope[t][:])*p.max_sizes[t]+maximum(p.seg_yint[t][:]))*(1-m[:binMGTechUsed][t])
+                        (maximum(p.cap_cost_slope[t][s] for s in 1:p.n_segs_by_tech[t]) * p.max_sizes[t] + maximum(p.seg_yint[t][s] for s in 1:p.n_segs_by_tech[t]))*(1-m[:binMGTechUsed][t])
                 )
             @constraint(m, [t in p.techs.segmented], m[:dvMGTechUpgradeCost][t] >= 0.0)
         end
@@ -324,11 +324,11 @@ function add_MG_storage_dispatch_constraints(m,p)
         )
     else
         @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-            sum(m[:dvMGProductionToStorage][t, s, tz, ts] for t in p.techs.elec) <= p.s.storage_attr[b].max_kw * m[:binMGStorageUsed]
+            sum(m[:dvMGProductionToStorage][t, s, tz, ts] for t in p.techs.elec) <= p.s.storage.attr["ElectricStorage"].max_kw * m[:binMGStorageUsed]
         )
         
         @constraint(m, [s in p.s.electric_utility.scenarios, tz in p.s.electric_utility.outage_start_time_steps, ts in p.s.electric_utility.outage_time_steps],
-            m[:dvMGDischargeFromStorage][s, tz, ts] <= p.s.storage_attr[b].max_kw * m[:binMGStorageUsed]
+            m[:dvMGDischargeFromStorage][s, tz, ts] <= p.s.storage.attr["ElectricStorage"].max_kw * m[:binMGStorageUsed]
         )
     end
 end

--- a/src/core/settings.jl
+++ b/src/core/settings.jl
@@ -9,7 +9,7 @@ Captures high-level inputs affecting the optimization.
     off_grid_flag::Bool = false # true if modeling an off-grid system, not connected to bulk power system
     include_climate_in_objective::Bool = false # true if climate costs of emissions should be included in the model's objective function
     include_health_in_objective::Bool = false # true if health costs of emissions should be included in the model's objective function
-    solver_id::String = "HiGHS" # solver used to obtain a solution to model instance. available options: ["HiGHS", "Cbc", "CPLEX", "Xpress"]
+    solver_name::String = "HiGHS" # solver used to obtain a solution to model instance. available options: ["HiGHS", "Cbc", "CPLEX", "Xpress"]
 ```
 """
 Base.@kwdef struct Settings
@@ -18,5 +18,5 @@ Base.@kwdef struct Settings
     off_grid_flag::Bool = false # true if modeling an off-grid system, not connected to bulk power system
     include_climate_in_objective::Bool = false # true if climate costs of emissions should be included in the model's objective function
     include_health_in_objective::Bool = false # true if health costs of emissions should be included in the model's objective function
-    solver_id::String = "HiGHS" # solver used to obtain a solution to model instance. available options: ["HiGHS", "Cbc", "CPLEX", "Xpress"]
+    solver_name::String = "HiGHS" # solver used to obtain a solution to model instance. available options: ["HiGHS", "Cbc", "CPLEX", "Xpress"]
 end

--- a/src/core/settings.jl
+++ b/src/core/settings.jl
@@ -9,6 +9,7 @@ Captures high-level inputs affecting the optimization.
     off_grid_flag::Bool = false # true if modeling an off-grid system, not connected to bulk power system
     include_climate_in_objective::Bool = false # true if climate costs of emissions should be included in the model's objective function
     include_health_in_objective::Bool = false # true if health costs of emissions should be included in the model's objective function
+    solver_id::String = "HiGHS" # solver used to obtain a solution to model instance. available options: ["HiGHS", "Cbc", "CPLEX", "Xpress"]
 ```
 """
 Base.@kwdef struct Settings
@@ -17,4 +18,5 @@ Base.@kwdef struct Settings
     off_grid_flag::Bool = false # true if modeling an off-grid system, not connected to bulk power system
     include_climate_in_objective::Bool = false # true if climate costs of emissions should be included in the model's objective function
     include_health_in_objective::Bool = false # true if health costs of emissions should be included in the model's objective function
+    solver_id::String = "HiGHS" # solver used to obtain a solution to model instance. available options: ["HiGHS", "Cbc", "CPLEX", "Xpress"]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1955,7 +1955,7 @@ else  # run HiGHS tests
                 m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
                 results = run_reopt([m1, m2], inputs)
 
-                if !isnothing(ER_target[i])  #TODO this is just an if statement in Xpress
+                if !isnothing(ER_target[i])  
                     ER_fraction_out = results["Site"]["lifecycle_emissions_reduction_CO2_fraction"]
                     @test ER_target[i] ≈ ER_fraction_out atol=1e-3
                     lifecycle_emissions_tonnes_CO2_out = results["Site"]["lifecycle_emissions_tonnes_CO2"]
@@ -1965,16 +1965,14 @@ else  # run HiGHS tests
                     @test ER_fraction_diff ≈ 0.0 atol=1e-2
                 end
 
-                for i in 1:3 #TODO make this block general for all i when test is restored
-                    annual_emissions_tonnes_CO2_out = results["Site"]["annual_emissions_tonnes_CO2"]
-                    yr1_fuel_emissions_tonnes_CO2_out = results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2"]
-                    yr1_grid_emissions_tonnes_CO2_out = results["ElectricUtility"]["annual_emissions_tonnes_CO2"]
-                    yr1_total_emissions_calced_tonnes_CO2 = yr1_fuel_emissions_tonnes_CO2_out + yr1_grid_emissions_tonnes_CO2_out 
-                    @test annual_emissions_tonnes_CO2_out ≈ yr1_total_emissions_calced_tonnes_CO2 atol=1e-1
-                    if haskey(results["Financial"],"breakeven_cost_of_emissions_reduction_per_tonne_CO2")
-                        @test results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"] >= 0.0
-                    end
-                end 
+                annual_emissions_tonnes_CO2_out = results["Site"]["annual_emissions_tonnes_CO2"]
+                yr1_fuel_emissions_tonnes_CO2_out = results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2"]
+                yr1_grid_emissions_tonnes_CO2_out = results["ElectricUtility"]["annual_emissions_tonnes_CO2"]
+                yr1_total_emissions_calced_tonnes_CO2 = yr1_fuel_emissions_tonnes_CO2_out + yr1_grid_emissions_tonnes_CO2_out 
+                @test annual_emissions_tonnes_CO2_out ≈ yr1_total_emissions_calced_tonnes_CO2 atol=1e-1
+                if haskey(results["Financial"],"breakeven_cost_of_emissions_reduction_per_tonne_CO2")
+                    @test results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"] >= 0.0
+                end
                 
                 if i == 1
                     @test results["PV"]["size_kw"] ≈ 60.12 atol=1e-1
@@ -2028,8 +2026,8 @@ else  # run HiGHS tests
                     inputs["ElectricStorage"]["max_kwh"] = results["ElectricStorage"]["size_kwh"]
                     inputs["Financial"]["CO2_cost_per_tonne"] = results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"]
                     inputs["Settings"]["include_climate_in_objective"] = true
-                    m1 = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
-                    m2 = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
+                    m1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
+                    m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
                     results = run_reopt([m1, m2], inputs)
                     @test results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"] ≈ inputs["Financial"]["CO2_cost_per_tonne"] atol=1e-1
                 elseif i == 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -705,16 +705,14 @@ else  # run HiGHS tests
                 s = Scenario(data)
                 inputs = REoptInputs(s)
                 results = run_reopt(m1, inputs)
-                @test occursin("not supported by the solver", string(results["Messages"]["errors"]))
-
-                # @test results["CHP"]["size_kw"] == 800
-                # @test results["CHP"]["size_supplemental_firing_kw"] == 0
-                # @test results["CHP"]["annual_electric_production_kwh"] ≈ 800*8760 rtol=1e-5
-                # @test results["CHP"]["annual_thermal_production_mmbtu"] ≈ 800*(0.4418/0.3573)*8760/293.07107 rtol=1e-5
-                # @test results["ElectricTariff"]["lifecycle_demand_cost_after_tax"] == 0
-                # @test results["HeatingLoad"]["annual_calculated_total_heating_thermal_load_mmbtu"] == 12.0 * 8760 * data["ExistingBoiler"]["efficiency"]
-                # @test results["HeatingLoad"]["annual_calculated_dhw_thermal_load_mmbtu"] == 6.0 * 8760 * data["ExistingBoiler"]["efficiency"]
-                # @test results["HeatingLoad"]["annual_calculated_space_heating_thermal_load_mmbtu"] == 6.0 * 8760 * data["ExistingBoiler"]["efficiency"]
+                @test results["CHP"]["size_kw"] == 800
+                @test results["CHP"]["size_supplemental_firing_kw"] == 0
+                @test results["CHP"]["annual_electric_production_kwh"] ≈ 800*8760 rtol=1e-5
+                @test results["CHP"]["annual_thermal_production_mmbtu"] ≈ 800*(0.4418/0.3573)*8760/293.07107 rtol=1e-5
+                @test results["ElectricTariff"]["lifecycle_demand_cost_after_tax"] == 0
+                @test results["HeatingLoad"]["annual_calculated_total_heating_thermal_load_mmbtu"] == 12.0 * 8760 * data["ExistingBoiler"]["efficiency"]
+                @test results["HeatingLoad"]["annual_calculated_dhw_thermal_load_mmbtu"] == 6.0 * 8760 * data["ExistingBoiler"]["efficiency"]
+                @test results["HeatingLoad"]["annual_calculated_space_heating_thermal_load_mmbtu"] == 6.0 * 8760 * data["ExistingBoiler"]["efficiency"]
             
                 #part 2: supplementary firing used when more efficient than the boiler and low-cost; demand charges not reduced by CHP
                 data["CHP"]["supplementary_firing_capital_cost_per_kw"] = 10
@@ -724,10 +722,9 @@ else  # run HiGHS tests
                 s = Scenario(data)
                 inputs = REoptInputs(s)
                 results = run_reopt(m2, inputs)
-                @test occursin("not supported by the solver", string(results["Messages"]["errors"]))
-                # @test results["CHP"]["size_supplemental_firing_kw"] ≈ 321.71 atol=0.1
-                # @test results["CHP"]["annual_thermal_production_mmbtu"] ≈ 149136.6 rtol=1e-5
-                # @test results["ElectricTariff"]["lifecycle_demand_cost_after_tax"] ≈ 5212.7 rtol=1e-5
+                @test results["CHP"]["size_supplemental_firing_kw"] ≈ 321.71 atol=0.1
+                @test results["CHP"]["annual_thermal_production_mmbtu"] ≈ 149136.6 rtol=1e-5
+                @test results["ElectricTariff"]["lifecycle_demand_cost_after_tax"] ≈ 5212.7 rtol=1e-5
             end
         end
         

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -912,15 +912,14 @@ else  # run HiGHS tests
                 
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.01, "presolve" => "on"))
             results = run_reopt(m, "./scenarios/outage.json")
-            @test occursin("not supported by the solver", string(results["Messages"]["errors"]))
 
-            # @test results["Outages"]["expected_outage_cost"] ≈ 0
-            # @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 0
-            # @test value(m[:binMGTechUsed]["Generator"]) ≈ 1
-            # @test value(m[:binMGTechUsed]["CHP"]) ≈ 1
-            # @test value(m[:binMGTechUsed]["PV"]) ≈ 1
-            # @test value(m[:binMGStorageUsed]) ≈ 1
-            # @test results["Financial"]["lcc"] ≈ 6.83633907986e7 atol=5e4
+            @test results["Outages"]["expected_outage_cost"] ≈ 0
+            @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 0
+            @test value(m[:binMGTechUsed]["Generator"]) ≈ 1
+            @test value(m[:binMGTechUsed]["CHP"]) ≈ 1
+            @test value(m[:binMGTechUsed]["PV"]) ≈ 1
+            @test value(m[:binMGStorageUsed]) ≈ 1
+            @test results["Financial"]["lcc"] ≈ 6.83633907986e7 rtol=0.01
 
             #=
             Scenario with $0.001/kWh value_of_lost_load_per_kwh, 12x169 hour outages, 1kW load/hour, and min_resil_time_steps = 168
@@ -928,33 +927,29 @@ else  # run HiGHS tests
             =#
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
             results = run_reopt(m, "./scenarios/nogridcost_minresilhours.json")
-            @test occursin("not supported by the solver", string(results["Messages"]["errors"]))
-            # @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 12
+            @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 12
             
             # testing dvUnserved load, which would output 100 kWh for this scenario before output fix
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
             results = run_reopt(m, "./scenarios/nogridcost_multiscenario.json")
-            @test occursin("not supported by the solver", string(results["Messages"]["errors"]))
-            # @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 60
-            # @test results["Outages"]["expected_outage_cost"] ≈ 485.43270 atol=1.0e-5  #avg duration (3h) * load per time step (10) * present worth factor (16.18109)
-            # @test results["Outages"]["max_outage_cost_per_outage_duration"][1] ≈ 161.8109 atol=1.0e-5
+            @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 60
+            @test results["Outages"]["expected_outage_cost"] ≈ 485.43270 atol=1.0e-5  #avg duration (3h) * load per time step (10) * present worth factor (16.18109)
+            @test results["Outages"]["max_outage_cost_per_outage_duration"][1] ≈ 161.8109 atol=1.0e-5
 
             # Scenario with generator, PV, electric storage
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
             results = run_reopt(m, "./scenarios/outages_gen_pv_stor.json")
-            @test occursin("not supported by the solver", string(results["Messages"]["errors"]))
-            # @test results["Outages"]["expected_outage_cost"] ≈ 3.54476923e6 atol=10
-            # @test results["Financial"]["lcc"] ≈ 8.6413594727e7 rtol=0.001
+            @test results["Outages"]["expected_outage_cost"] ≈ 3.54476923e6 atol=10
+            @test results["Financial"]["lcc"] ≈ 8.6413594727e7 rtol=0.001
 
             # Scenario with generator, PV, wind, electric storage
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
-            results = run_reopt(m, "./scenarios/outages_gen_pv_wind_stor.json")
-            @test occursin("not supported by the solver", string(results["Messages"]["errors"]))
-            # @test value(m[:binMGTechUsed]["Generator"]) ≈ 1
-            # @test value(m[:binMGTechUsed]["PV"]) ≈ 1
-            # @test value(m[:binMGTechUsed]["Wind"]) ≈ 1
-            # @test results["Outages"]["expected_outage_cost"] ≈ 446899.75 atol=1.0
-            # @test results["Financial"]["lcc"] ≈ 6.71661825335e7 rtol=0.001
+            results = run_reopt(m, "./scenarios/outages_gen_pv_wind_stor.json")\
+            @test value(m[:binMGTechUsed]["Generator"]) ≈ 1
+            @test value(m[:binMGTechUsed]["PV"]) ≈ 1
+            @test value(m[:binMGTechUsed]["Wind"]) ≈ 1
+            @test results["Outages"]["expected_outage_cost"] ≈ 446899.75 atol=1.0
+            @test results["Financial"]["lcc"] ≈ 6.71661825335e7 rtol=0.001
         end
 
         @testset "Outages with Wind and supply-to-load no greater than critical load" begin
@@ -964,17 +959,16 @@ else  # run HiGHS tests
             m1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.01, "presolve" => "on"))
             m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.01, "presolve" => "on"))
             results = run_reopt([m1,m2], inputs)
-            @test (occursin("not supported by the solver", string(results["Messages"]["errors"])) || occursin("REopt scenarios solved either with errors or non-optimal solutions", string(results["Messages"]["errors"])))
                 
-            # # Check that supply-to-load is equal to critical load during outages, including wind
-            # supply_to_load = results["Outages"]["storage_discharge_series_kw"] .+ results["Outages"]["wind_to_load_series_kw"]
-            # supply_to_load = [supply_to_load[:,:,i][1] for i in eachindex(supply_to_load)]
-            # critical_load = results["Outages"]["critical_loads_per_outage_series_kw"][1,1,:]
-            # check = .≈(supply_to_load, critical_load, atol=0.001)
-            # @test !(0 in check)
+            # Check that supply-to-load is equal to critical load during outages, including wind
+            supply_to_load = results["Outages"]["storage_discharge_series_kw"] .+ results["Outages"]["wind_to_load_series_kw"]
+            supply_to_load = [supply_to_load[:,:,i][1] for i in eachindex(supply_to_load)]
+            critical_load = results["Outages"]["critical_loads_per_outage_series_kw"][1,1,:]
+            check = .≈(supply_to_load, critical_load, atol=0.001)
+            @test !(0 in check)
 
-            # # Check that the soc_series_fraction is the same length as the storage_discharge_series_kw
-            # @test size(results["Outages"]["soc_series_fraction"]) == size(results["Outages"]["storage_discharge_series_kw"])
+            # Check that the soc_series_fraction is the same length as the storage_discharge_series_kw
+            @test size(results["Outages"]["soc_series_fraction"]) == size(results["Outages"]["storage_discharge_series_kw"])
         end
 
         @testset "Multiple Sites" begin
@@ -1960,11 +1954,8 @@ else  # run HiGHS tests
                 m1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
                 m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
                 results = run_reopt([m1, m2], inputs)
-                if i <= 2  
-                    @test (occursin("not supported by the solver", string(results["Messages"]["errors"])) || occursin("REopt scenarios solved either with errors or non-optimal solutions", string(results["Messages"]["errors"])))
-                
 
-                elseif !isnothing(ER_target[i])  #TODO this is just an if statement in Xpress
+                if !isnothing(ER_target[i])  #TODO this is just an if statement in Xpress
                     ER_fraction_out = results["Site"]["lifecycle_emissions_reduction_CO2_fraction"]
                     @test ER_target[i] ≈ ER_fraction_out atol=1e-3
                     lifecycle_emissions_tonnes_CO2_out = results["Site"]["lifecycle_emissions_tonnes_CO2"]
@@ -1974,7 +1965,7 @@ else  # run HiGHS tests
                     @test ER_fraction_diff ≈ 0.0 atol=1e-2
                 end
 
-                if i == 3 #TODO make this block general for all i when test is restored
+                for i in 1:3 #TODO make this block general for all i when test is restored
                     annual_emissions_tonnes_CO2_out = results["Site"]["annual_emissions_tonnes_CO2"]
                     yr1_fuel_emissions_tonnes_CO2_out = results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2"]
                     yr1_grid_emissions_tonnes_CO2_out = results["ElectricUtility"]["annual_emissions_tonnes_CO2"]
@@ -1985,83 +1976,63 @@ else  # run HiGHS tests
                     end
                 end 
                 
-                # TODO: refresh tests and test values as needed once able to uncomment; revised values are in test_with_xpress.jl
-                # if i == 1
-                #     @test results["PV"]["size_kw"] ≈ 60.12 atol=1e-1
-                #     @test results["ElectricStorage"]["size_kw"] ≈ 0.0 atol=1e-1
-                #     @test results["ElectricStorage"]["size_kwh"] ≈ 0.0 atol=1e-1
-                #     @test results["Generator"]["size_kw"] ≈ 21.52 atol=1e-1
-                #     @test results["Site"]["annual_renewable_electricity_kwh"] ≈ 76412.02
-                #     @test results["Site"]["renewable_electricity_fraction"] ≈ 0.8
-                #     @test results["Site"]["renewable_electricity_fraction_bau"] ≈ 0.147576 atol=1e-4
-                #     @test results["Site"]["total_renewable_energy_fraction"] ≈ 0.8
-                #     @test results["Site"]["total_renewable_energy_fraction_bau"] ≈ 0.147576 atol=1e-4
-                #     @test results["Site"]["lifecycle_emissions_reduction_CO2_fraction"] ≈ 0.616639 atol=1e-4
-                #     @test results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"] ≈ 281.6 atol=1
-                #     @test results["Site"]["annual_emissions_tonnes_CO2"] ≈ 11.38 atol=1e-2
-                #     @test results["Site"]["annual_emissions_tonnes_CO2_bau"] ≈ 32.06 atol=1e-2
-                #     @test results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2"] ≈ 7.04
-                #     @test results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2_bau"] ≈ 0.0
-                #     @test results["Financial"]["lifecycle_emissions_cost_climate"] ≈ 7767.6 atol=1
-                #     @test results["Financial"]["lifecycle_emissions_cost_climate_bau"] ≈ 20450.62 atol=1e-1
-                #     @test results["Site"]["lifecycle_emissions_tonnes_CO2"] ≈ 217.63
-                #     @test results["Site"]["lifecycle_emissions_tonnes_CO2_bau"] ≈ 567.77
-                #     @test results["Site"]["lifecycle_emissions_from_fuelburn_tonnes_CO2"] ≈ 140.78
-                #     @test results["Site"]["lifecycle_emissions_from_fuelburn_tonnes_CO2_bau"] ≈ 0.0
-                #     @test results["ElectricUtility"]["annual_emissions_tonnes_CO2"] ≈ 4.34
-                #     @test results["ElectricUtility"]["annual_emissions_tonnes_CO2_bau"] ≈ 32.06
-                #     @test results["ElectricUtility"]["lifecycle_emissions_tonnes_CO2"] ≈ 76.86
-                #     @test results["ElectricUtility"]["lifecycle_emissions_tonnes_CO2_bau"] ≈ 567.77
-                # elseif i == 2
-                #     #commented out values are results using same levelization factor as API
-                #     @test results["PV"]["size_kw"] ≈ 106.13 atol=1
-                #     @test results["ElectricStorage"]["size_kw"] ≈ 21.58 atol=1 # 20.29
-                #     @test results["ElectricStorage"]["size_kwh"] ≈ 165.27 atol=1
-                #     @test !haskey(results, "Generator")
-                #     # NPV
-                #     @info results["Financial"]["npv"]
-                #     expected_npv = -267404.54
-                #     @test (expected_npv - results["Financial"]["npv"])/expected_npv ≈ 0.0 atol=1e-3
-                #     # Renewable energy
-                #     @test results["Site"]["renewable_electricity_fraction"] ≈ 0.783298 atol=1e-3
-                #     @test results["Site"]["annual_renewable_electricity_kwh"] ≈ 78329.85 atol=10
-                #     @test results["Site"]["renewable_electricity_fraction_bau"] ≈ 0.132118 atol=1e-3 #0.1354 atol=1e-3
-                #     @test results["Site"]["annual_renewable_electricity_kwh_bau"] ≈ 13211.78 atol=10 # 13542.62 atol=10
-                #     @test results["Site"]["total_renewable_energy_fraction"] ≈ 0.783298 atol=1e-3
-                #     @test results["Site"]["total_renewable_energy_fraction_bau"] ≈ 0.132118 atol=1e-3 # 0.1354 atol=1e-3
-                #     # CO2 emissions - totals ≈  from grid, from fuelburn, ER, $/tCO2 breakeven
-                #     @test results["Site"]["lifecycle_emissions_reduction_CO2_fraction"] ≈ 0.8 atol=1e-3 # 0.8
-                #     @test results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"] ≈ 373.9 atol=1e-1
-                #     @test results["Site"]["annual_emissions_tonnes_CO2"] ≈ 14.2 atol=1
-                #     @test results["Site"]["annual_emissions_tonnes_CO2_bau"] ≈ 70.99 atol=1
-                #     @test results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2"] ≈ 0.0 atol=1 # 0.0
-                #     @test results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2_bau"] ≈ 0.0 atol=1 # 0.0
-                #     @test results["Financial"]["lifecycle_emissions_cost_climate"] ≈ 9110.21 atol=1
-                #     @test results["Financial"]["lifecycle_emissions_cost_climate_bau"] ≈ 45546.55 atol=1
-                #     @test results["Site"]["lifecycle_emissions_tonnes_CO2"] ≈ 252.92 atol=1
-                #     @test results["Site"]["lifecycle_emissions_tonnes_CO2_bau"] ≈ 1264.62 atol=1
-                #     @test results["Site"]["lifecycle_emissions_from_fuelburn_tonnes_CO2"] ≈ 0.0 atol=1 # 0.0
-                #     @test results["Site"]["lifecycle_emissions_from_fuelburn_tonnes_CO2_bau"] ≈ 0.0 atol=1 # 0.0
-                #     @test results["ElectricUtility"]["annual_emissions_tonnes_CO2"] ≈ 14.2 atol=1
-                #     @test results["ElectricUtility"]["annual_emissions_tonnes_CO2_bau"] ≈ 70.99 atol=1
-                #     @test results["ElectricUtility"]["lifecycle_emissions_tonnes_CO2"] ≈ 252.92 atol=1
-                #     @test results["ElectricUtility"]["lifecycle_emissions_tonnes_CO2_bau"] ≈ 1264.62 atol=1
-
-                #     #also test CO2 breakeven cost
-                #     inputs["PV"]["min_kw"] = results["PV"]["size_kw"] - inputs["PV"]["existing_kw"]
-                #     inputs["PV"]["max_kw"] = results["PV"]["size_kw"] - inputs["PV"]["existing_kw"]
-                #     inputs["ElectricStorage"]["min_kw"] = results["ElectricStorage"]["size_kw"]
-                #     inputs["ElectricStorage"]["max_kw"] = results["ElectricStorage"]["size_kw"]
-                #     inputs["ElectricStorage"]["min_kwh"] = results["ElectricStorage"]["size_kwh"]
-                #     inputs["ElectricStorage"]["max_kwh"] = results["ElectricStorage"]["size_kwh"]
-                #     inputs["Financial"]["CO2_cost_per_tonne"] = results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"]
-                #     inputs["Settings"]["include_climate_in_objective"] = true
-                #     m1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
-                #     m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
-                #     results = run_reopt([m1, m2], inputs)
-                #     @test results["Financial"]["npv"]/expected_npv ≈ 0 atol=1e-3
-                #     @test results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"] ≈ inputs["Financial"]["CO2_cost_per_tonne"] atol=1e-1
-                if i == 3
+                if i == 1
+                    @test results["PV"]["size_kw"] ≈ 60.12 atol=1e-1
+                    @test results["ElectricStorage"]["size_kw"] ≈ 0.0 atol=1e-1
+                    @test results["ElectricStorage"]["size_kwh"] ≈ 0.0 atol=1e-1
+                    @test results["Generator"]["size_kw"] ≈ 21.52 atol=1e-1
+                    @test results["Site"]["total_renewable_energy_fraction"] ≈ 0.8
+                    @test results["Site"]["total_renewable_energy_fraction_bau"] ≈ 0.147576 atol=1e-4
+                    @test results["Site"]["lifecycle_emissions_reduction_CO2_fraction"] ≈ 0.58694032 atol=1e-4
+                    @test results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"] ≈ 355.8 atol=1
+                    @test results["Site"]["annual_emissions_tonnes_CO2"] ≈ 11.64 atol=1e-2
+                    @test results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2"] ≈ 7.0605
+                    @test results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2_bau"] ≈ 0.0
+                    @test results["Financial"]["lifecycle_emissions_cost_climate"] ≈ 8315.69 atol=1
+                    @test results["Site"]["lifecycle_emissions_tonnes_CO2"] ≈ 232.85
+                    @test results["Site"]["lifecycle_emissions_from_fuelburn_tonnes_CO2"] ≈ 141.21
+                    @test results["Site"]["lifecycle_emissions_from_fuelburn_tonnes_CO2_bau"] ≈ 0.0
+                    @test results["ElectricUtility"]["annual_emissions_tonnes_CO2_bau"] ≈ 28.186 atol=1e-1
+                    @test results["ElectricUtility"]["lifecycle_emissions_tonnes_CO2_bau"] ≈ 563.72
+                elseif i == 2
+                    #commented out values are results using same levelization factor as API
+                    @test results["PV"]["size_kw"] ≈ 106.13 atol=1
+                    @test results["ElectricStorage"]["size_kw"] ≈ 21.58 atol=1 # 20.29
+                    @test results["ElectricStorage"]["size_kwh"] ≈ 166.29 atol=1
+                    @test !haskey(results, "Generator")
+                    # Renewable energy
+                    @test results["Site"]["renewable_electricity_fraction"] ≈ 0.78586 atol=1e-3
+                    @test results["Site"]["renewable_electricity_fraction_bau"] ≈ 0.132118 atol=1e-3 #0.1354 atol=1e-3
+                    @test results["Site"]["annual_renewable_electricity_kwh_bau"] ≈ 13211.78 atol=10 # 13542.62 atol=10
+                    @test results["Site"]["total_renewable_energy_fraction_bau"] ≈ 0.132118 atol=1e-3 # 0.1354 atol=1e-3
+                    # CO2 emissions - totals ≈  from grid, from fuelburn, ER, $/tCO2 breakeven
+                    @test results["Site"]["lifecycle_emissions_reduction_CO2_fraction"] ≈ 0.8 atol=1e-3 # 0.8
+                    @test results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"] ≈ 460.7 atol=1e-1
+                    @test results["Site"]["annual_emissions_tonnes_CO2"] ≈ 11.662 atol=1
+                    @test results["Site"]["annual_emissions_tonnes_CO2_bau"] ≈ 58.3095 atol=1
+                    @test results["Site"]["annual_emissions_from_fuelburn_tonnes_CO2"] ≈ 0.0 atol=1 # 0.0
+                    @test results["Financial"]["lifecycle_emissions_cost_climate"] ≈ 8401.1 atol=1
+                    @test results["Site"]["lifecycle_emissions_tonnes_CO2_bau"] ≈ 1166.19 atol=1
+                    @test results["Site"]["lifecycle_emissions_from_fuelburn_tonnes_CO2"] ≈ 0.0 atol=1 # 0.0
+                    @test results["Site"]["lifecycle_emissions_from_fuelburn_tonnes_CO2_bau"] ≈ 0.0 atol=1 # 0.0
+                    @test results["ElectricUtility"]["annual_emissions_tonnes_CO2_bau"] ≈ 58.3095 atol=1
+                    @test results["ElectricUtility"]["lifecycle_emissions_tonnes_CO2"] ≈ 233.24 atol=1
+        
+        
+                    #also test CO2 breakeven cost
+                    inputs["PV"]["min_kw"] = results["PV"]["size_kw"] - inputs["PV"]["existing_kw"]
+                    inputs["PV"]["max_kw"] = results["PV"]["size_kw"] - inputs["PV"]["existing_kw"]
+                    inputs["ElectricStorage"]["min_kw"] = results["ElectricStorage"]["size_kw"]
+                    inputs["ElectricStorage"]["max_kw"] = results["ElectricStorage"]["size_kw"]
+                    inputs["ElectricStorage"]["min_kwh"] = results["ElectricStorage"]["size_kwh"]
+                    inputs["ElectricStorage"]["max_kwh"] = results["ElectricStorage"]["size_kwh"]
+                    inputs["Financial"]["CO2_cost_per_tonne"] = results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"]
+                    inputs["Settings"]["include_climate_in_objective"] = true
+                    m1 = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
+                    m2 = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
+                    results = run_reopt([m1, m2], inputs)
+                    @test results["Financial"]["breakeven_cost_of_emissions_reduction_per_tonne_CO2"] ≈ inputs["Financial"]["CO2_cost_per_tonne"] atol=1e-1
+                elseif i == 3
                     @test results["PV"]["size_kw"] ≈ 20.0 atol=1e-1
                     @test !haskey(results, "Wind")
                     @test !haskey(results, "ElectricStorage")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1133,9 +1133,8 @@ else  # run HiGHS tests
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
             d = JSON.parsefile("./scenarios/wind.json")
             results = run_reopt(m, d)
-            @test occursin("not supported by the solver", string(results["Messages"]["errors"]))
-            # @test results["Wind"]["size_kw"] ≈ 3752 atol=0.1
-            # @test results["Financial"]["lcc"] ≈ 8.591017e6 rtol=1e-5
+            @test results["Wind"]["size_kw"] ≈ 3752 atol=0.1
+            @test results["Financial"]["lcc"] ≈ 8.591017e6 rtol=1e-5
             #= 
             0.5% higher LCC in this package as compared to API ? 8,591,017 vs 8,551,172
             - both have zero curtailment
@@ -1154,15 +1153,13 @@ else  # run HiGHS tests
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
             d["Site"]["land_acres"] = 60 # = 2 MW (with 0.03 acres/kW)
             results = run_reopt(m, d)
-            @test occursin("not supported by the solver", string(results["Messages"]["errors"]))
-            # @test results["Wind"]["size_kw"] == 2000.0 # Wind should be constrained by land_acres
+            @test results["Wind"]["size_kw"] == 2000.0 # Wind should be constrained by land_acres
 
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
             d["Wind"]["min_kw"] = 2001 # min_kw greater than land-constrained max should error
             results = run_reopt(m, d)
             @test "errors" ∈ keys(results["Messages"])
             @test length(results["Messages"]["errors"]) > 0
-            
         end
 
         @testset "Multiple PVs" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -839,10 +839,9 @@ else  # run HiGHS tests
             s = Scenario(data)
             inputs = REoptInputs(s)
             results = run_reopt(model, inputs)
-            @test (occursin("not supported by the solver", string(results["Messages"]["errors"])) || occursin("REopt scenarios solved either with errors or non-optimal solutions", string(results["Messages"]["errors"])))
-
-            # @test all(x == 0.0 for (i,x) in enumerate(results["ElectricUtility"]["electric_to_load_series_kw"][1:744]) 
-            #         if results["PV"]["electric_to_grid_series_kw"][i] > 0)
+            
+            @test all(x == 0.0 for (i,x) in enumerate(results["ElectricUtility"]["electric_to_load_series_kw"][1:744]) 
+                    if results["PV"]["electric_to_grid_series_kw"][i] > 0)
         end
 
         @testset "Solar and ElectricStorage w/BAU and degradation" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -944,7 +944,7 @@ else  # run HiGHS tests
 
             # Scenario with generator, PV, wind, electric storage
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
-            results = run_reopt(m, "./scenarios/outages_gen_pv_wind_stor.json")\
+            results = run_reopt(m, "./scenarios/outages_gen_pv_wind_stor.json")
             @test value(m[:binMGTechUsed]["Generator"]) ≈ 1
             @test value(m[:binMGTechUsed]["PV"]) ≈ 1
             @test value(m[:binMGTechUsed]["Wind"]) ≈ 1

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -457,7 +457,9 @@ end
 @testset "Minimize Unserved Load" begin
         
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "MIPRELSTOP" => 0.01, "OUTPUTLOG" => 0))
-    results = run_reopt(m, "./scenarios/outage.json")
+    input_data = JSON.parsefile("./scenarios/outage.json")
+    input_data["Settings"] = Dict("solver_name" => "Xpress")
+    results = run_reopt(m, input_data)
 
     @test results["Outages"]["expected_outage_cost"] ≈ 0
     @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 0
@@ -472,25 +474,33 @@ end
     - should meet 168 kWh in each outage such that the total unserved load is 12 kWh
     =#
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
-    results = run_reopt(m, "./scenarios/nogridcost_minresilhours.json")
+    input_data = JSON.parsefile("./scenarios/nogridcost_minresilhours.json")
+    input_data["Settings"] = Dict("solver_name" => "Xpress")
+    results = run_reopt(m, input_data)
     @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 12
     
     # testing dvUnserved load, which would output 100 kWh for this scenario before output fix
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
-    results = run_reopt(m, "./scenarios/nogridcost_multiscenario.json")
+    input_data = JSON.parsefile("./scenarios/nogridcost_multiscenario.json")
+    input_data["Settings"] = Dict("solver_name" => "Xpress")
+    results = run_reopt(m, input_data)    
     @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 60
     @test results["Outages"]["expected_outage_cost"] ≈ 485.43270 atol=1.0e-5  #avg duration (3h) * load per time step (10) * present worth factor (16.18109)
     @test results["Outages"]["max_outage_cost_per_outage_duration"][1] ≈ 161.8109 atol=1.0e-5
 
     # Scenario with generator, PV, electric storage
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
-    results = run_reopt(m, "./scenarios/outages_gen_pv_stor.json")
+    input_data = JSON.parsefile("./scenarios/outages_gen_pv_stor.json")
+    input_data["Settings"] = Dict("solver_name" => "Xpress")
+    results = run_reopt(m, input_data)
     @test results["Outages"]["expected_outage_cost"] ≈ 3.54476923e6 atol=10
     @test results["Financial"]["lcc"] ≈ 8.6413594727e7 rtol=0.001
 
     # Scenario with generator, PV, wind, electric storage
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
-    results = run_reopt(m, "./scenarios/outages_gen_pv_wind_stor.json")
+    input_data = JSON.parsefile("./scenarios/outages_gen_pv_wind_stor.json")
+    input_data["Settings"] = Dict("solver_name" => "Xpress")
+    results = run_reopt(m, input_data)
     @test value(m[:binMGTechUsed]["Generator"]) ≈ 1
     @test value(m[:binMGTechUsed]["PV"]) ≈ 1
     @test value(m[:binMGTechUsed]["Wind"]) ≈ 1
@@ -500,6 +510,7 @@ end
 
 @testset "Outages with Wind and supply-to-load no greater than critical load" begin
     input_data = JSON.parsefile("./scenarios/wind_outages.json")
+    input_data["Settings"] = Dict("solver_name" => "Xpress")
     s = Scenario(input_data)
     inputs = REoptInputs(s)
     m1 = Model(optimizer_with_attributes(Xpress.Optimizer, "MIPRELSTOP" => 0.01, "OUTPUTLOG" => 0))


### PR DESCRIPTION
### Added 
- In `src/settings.jl`, added new const **INDICATOR_COMPATIBLE_SOLVERS**
- In `src/settings.jl`, added new member **solver_name** within the settings object.  This is currently not connected to the solver but does determine whether indicator constraints are modeled or if their big-M workarounds are used.
- Added replacements for indicator constraints with the exception of battery degradation, which is implemented in a separate model, and FlexibleHVAC.  TODO's have been added for these remaining cases.

### Fixed
- Fixed previously broken tests using HiGHS in `test/runtests.jl` due to solver incompatibility.