### PR TITLE
Fix blended CRB with one load zero annual energy

### DIFF
--- a/src/core/doe_commercial_reference_building_loads.jl
+++ b/src/core/doe_commercial_reference_building_loads.jl
@@ -218,7 +218,9 @@ function blend_and_scale_doe_profiles(
             monthly_scaler = length(blended_doe_reference_names)
         end
         for idx in 1:length(profiles)
-            profiles[idx] .*= total_kwh / annual_kwhs[idx] / monthly_scaler
+            if !(annual_kwhs[idx] == 0.0)
+                profiles[idx] .*= total_kwh / annual_kwhs[idx] / monthly_scaler
+            end
         end
     end
     for idx in 1:length(profiles)  # scale the profiles


### PR DESCRIPTION
When the annual energy of one of the CRB's is zero, the blended/campus CRB functionality breaks due to a divide-by-zero issue. This PR fixes that by checking first if the annual energy is zero to avoid the division.