### PR TITLE
Add process heat load results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Classify the change according to the following categories:
 - In `src/core/existing_boiler.jl`, added field **retire_in_optimal** to the ExistingBoiler struct
 - Info to user including name of PV and/or temperature datasource used and distance from site location to datasource location
 - Warning to user if data is not from NSRDB or if data is more than 200 miles away
-- - In `results/heating_cooling_load.jl`, added new fields **process_heat_thermal_load_series_mmbtu_per_hour**, **process_heat_boiler_fuel_load_series_mmbtu_per_hour**, **annual_calculated_process_heat_thermal_load_mmbtu**, and **annual_calculated_process_heat_boiler_fuel_load_mmbtu** to HeatingLoad results, with sum heating loads now including process heat 
+- In `results/heating_cooling_load.jl`, added new fields **process_heat_thermal_load_series_mmbtu_per_hour**, **process_heat_boiler_fuel_load_series_mmbtu_per_hour**, **annual_calculated_process_heat_thermal_load_mmbtu**, and **annual_calculated_process_heat_boiler_fuel_load_mmbtu** to HeatingLoad results, with sum heating loads now including process heat 
 ### Changed
 - Change the way we determine which dataset to utilize in the PVWatts API call. Previously, we utilized defined lat-long bounds to determine if "nsrdb" or "intl" data should be used in PVWatts call. Now, we call the Solar Dataset Query API (v2) (https://developer.nrel.gov/docs/solar/data-query/v2/) to determine the dataset to use, and include "tmy3" as an option, as this is currently the best-available data for many locations in Alaska. 
 - refactored **dvThermalProduction** to be separated in **dvCoolingProduction** and **dvHeatingProduction** with **dvHeatingProduction** now indexed on `p.heating_loads`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ Classify the change according to the following categories:
 - In `src/mpc/inputs.jl`, added new field **heating_loads**
 - In `src/core/existing_boiler.jl`, added field **retire_in_optimal** to the ExistingBoiler struct
 - Info to user including name of PV and/or temperature datasource used and distance from site location to datasource location
-- Warning to user if data is not from NSRDB or if data is more than 200 miles away 
+- Warning to user if data is not from NSRDB or if data is more than 200 miles away
+- - In `results/heating_cooling_load.jl`, added new fields **process_heat_thermal_load_series_mmbtu_per_hour**, **process_heat_boiler_fuel_load_series_mmbtu_per_hour**, **annual_calculated_process_heat_thermal_load_mmbtu**, and **annual_calculated_process_heat_boiler_fuel_load_mmbtu** to HeatingLoad results, with sum heating loads now including process heat 
 ### Changed
 - Change the way we determine which dataset to utilize in the PVWatts API call. Previously, we utilized defined lat-long bounds to determine if "nsrdb" or "intl" data should be used in PVWatts call. Now, we call the Solar Dataset Query API (v2) (https://developer.nrel.gov/docs/solar/data-query/v2/) to determine the dataset to use, and include "tmy3" as an option, as this is currently the best-available data for many locations in Alaska. 
 - refactored **dvThermalProduction** to be separated in **dvCoolingProduction** and **dvHeatingProduction** with **dvHeatingProduction** now indexed on `p.heating_loads`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "REopt"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
 authors = ["Nick Laws", "Hallie Dunham <hallie.dunham@nrel.gov>", "Bill Becker <william.becker@nrel.gov>", "Bhavesh Rathod <bhavesh.rathod@nrel.gov>", "Alex Zolan <alexander.aolan@nrel.gov>", "Amanda Farthing <amanda.farthing@nrel.gov>"]
-version = "0.45.0"
+version = "0.46.0"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/results/heating_cooling_load.jl
+++ b/src/results/heating_cooling_load.jl
@@ -78,7 +78,7 @@ function add_heating_load_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict
     r["dhw_boiler_fuel_load_series_mmbtu_per_hour"] = dhw_load_series_kw ./ KWH_PER_MMBTU ./ existing_boiler_efficiency
     r["space_heating_boiler_fuel_load_series_mmbtu_per_hour"] = space_heating_load_series_kw ./ KWH_PER_MMBTU ./ existing_boiler_efficiency
     r["process_heat_boiler_fuel_load_series_mmbtu_per_hour"] = process_heat_load_series_kw ./ KWH_PER_MMBTU ./ existing_boiler_efficiency
-    r["total_heating_boiler_fuel_load_series_mmbtu_per_hour"] = r["dhw_boiler_fuel_load_series_mmbtu_per_hour"] .+ r["space_heating_boiler_fuel_load_series_mmbtu_per_hour"] .+ r["process_heat_boiler_fuel__load_series_mmbtu_per_hour"] 
+    r["total_heating_boiler_fuel_load_series_mmbtu_per_hour"] = r["dhw_boiler_fuel_load_series_mmbtu_per_hour"] .+ r["space_heating_boiler_fuel_load_series_mmbtu_per_hour"] .+ r["process_heat_boiler_fuel_load_series_mmbtu_per_hour"] 
 
     r["annual_calculated_dhw_thermal_load_mmbtu"] = round(
         sum(r["dhw_thermal_load_series_mmbtu_per_hour"]) / p.s.settings.time_steps_per_hour, digits=2

--- a/src/results/heating_cooling_load.jl
+++ b/src/results/heating_cooling_load.jl
@@ -38,12 +38,15 @@ end
 `HeatingLoad` results keys:
 - `dhw_thermal_load_series_mmbtu_per_hour` vector of site domestic hot water load in every time step
 - `space_heating_thermal_load_series_mmbtu_per_hour` vector of site space heating load in every time step
+- `process_heat_thermal_load_series_mmbtu_per_hour` vector of site process heat load in every time step
 - `total_heating_thermal_load_series_mmbtu_per_hour` vector of sum heating load in every time step
 - `annual_calculated_dhw_thermal_load_mmbtu` sum of the `dhw_load_series_mmbtu_per_hour`
 - `annual_calculated_space_heating_thermal_load_mmbtu` sum of the `space_heating_thermal_load_series_mmbtu_per_hour`
+- `annual_calculated_process_heat_thermal_load_mmbtu` sum of the `process_heat_thermal_load_series_mmbtu_per_hour`
 - `annual_calculated_total_heating_thermal_load_mmbtu` sum of the `total_heating_thermal_load_series_mmbtu_per_hour`
 - `annual_calculated_dhw_boiler_fuel_load_mmbtu`
 - `annual_calculated_space_heating_boiler_fuel_load_mmbtu`
+- `annual_calculated_process_heat_boiler_fuel_load_mmbtu`
 - `annual_calculated_total_heating_boiler_fuel_load_mmbtu`
 """
 function add_heating_load_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
@@ -65,12 +68,12 @@ function add_heating_load_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict
     
     r["dhw_thermal_load_series_mmbtu_per_hour"] = dhw_load_series_kw ./ KWH_PER_MMBTU
     r["space_heating_thermal_load_series_mmbtu_per_hour"] = space_heating_load_series_kw ./ KWH_PER_MMBTU
-    r["process_heat_thermal_load_series_mmbtu_per_hour"] = process_heating_load_series_kw ./ KWH_PER_MMBTU
-    r["total_heating_thermal_load_series_mmbtu_per_hour"] = r["dhw_thermal_load_series_mmbtu_per_hour"] .+ r["space_heating_thermal_load_series_mmbtu_per_hour" .+ r["process_heat_thermal_load_series_mmbtu_per_hour"]]
+    r["process_heat_thermal_load_series_mmbtu_per_hour"] = process_heat_load_series_kw ./ KWH_PER_MMBTU
+    r["total_heating_thermal_load_series_mmbtu_per_hour"] = r["dhw_thermal_load_series_mmbtu_per_hour"] .+ r["space_heating_thermal_load_series_mmbtu_per_hour"] .+ r["process_heat_thermal_load_series_mmbtu_per_hour"]
 
     r["dhw_boiler_fuel_load_series_mmbtu_per_hour"] = dhw_load_series_kw ./ KWH_PER_MMBTU ./ existing_boiler_efficiency
     r["space_heating_boiler_fuel_load_series_mmbtu_per_hour"] = space_heating_load_series_kw ./ KWH_PER_MMBTU ./ existing_boiler_efficiency
-    r["process_heat_boiler_fuel__load_series_mmbtu_per_hour"] = process_heating_load_series_kw ./ KWH_PER_MMBTU ./ existing_boiler_efficiency
+    r["process_heat_boiler_fuel_load_series_mmbtu_per_hour"] = process_heat_load_series_kw ./ KWH_PER_MMBTU ./ existing_boiler_efficiency
     r["total_heating_boiler_fuel_load_series_mmbtu_per_hour"] = r["dhw_boiler_fuel_load_series_mmbtu_per_hour"] .+ r["space_heating_boiler_fuel_load_series_mmbtu_per_hour"] .+ r["process_heat_boiler_fuel__load_series_mmbtu_per_hour"] 
 
     r["annual_calculated_dhw_thermal_load_mmbtu"] = round(

--- a/src/results/heating_cooling_load.jl
+++ b/src/results/heating_cooling_load.jl
@@ -36,18 +36,22 @@ end
 
 """
 `HeatingLoad` results keys:
-- `dhw_thermal_load_series_mmbtu_per_hour` vector of site domestic hot water load in every time step
-- `space_heating_thermal_load_series_mmbtu_per_hour` vector of site space heating load in every time step
-- `process_heat_thermal_load_series_mmbtu_per_hour` vector of site process heat load in every time step
-- `total_heating_thermal_load_series_mmbtu_per_hour` vector of sum heating load in every time step
-- `annual_calculated_dhw_thermal_load_mmbtu` sum of the `dhw_load_series_mmbtu_per_hour`
+- `dhw_thermal_load_series_mmbtu_per_hour` vector of site thermal domestic hot water load in every time step 
+- `space_heating_thermal_load_series_mmbtu_per_hour` vector of site thermal space heating load in every time step
+- `process_heat_thermal_load_series_mmbtu_per_hour` vector of site thermal process heat load in every time step
+- `total_heating_thermal_load_series_mmbtu_per_hour` vector of sum thermal heating load in every time step
+- `dhw_boiler_fuel_load_series_mmbtu_per_hour` vector of site fuel domestic hot water load in every time step
+- `space_heating_boiler_fuel_load_series_mmbtu_per_hour` vector of site fuel space heating load in every time step
+- `process_heat_boiler_fuel_load_series_mmbtu_per_hour` vector of site fuel process heat load in every time step
+- `total_heating_thermal_load_series_mmbtu_per_hour` vector of sum fuel heating load in every time step
+- `annual_calculated_dhw_thermal_load_mmbtu` sum of the `dhw_thermal_load_series_mmbtu_per_hour`
 - `annual_calculated_space_heating_thermal_load_mmbtu` sum of the `space_heating_thermal_load_series_mmbtu_per_hour`
 - `annual_calculated_process_heat_thermal_load_mmbtu` sum of the `process_heat_thermal_load_series_mmbtu_per_hour`
 - `annual_calculated_total_heating_thermal_load_mmbtu` sum of the `total_heating_thermal_load_series_mmbtu_per_hour`
-- `annual_calculated_dhw_boiler_fuel_load_mmbtu`
-- `annual_calculated_space_heating_boiler_fuel_load_mmbtu`
-- `annual_calculated_process_heat_boiler_fuel_load_mmbtu`
-- `annual_calculated_total_heating_boiler_fuel_load_mmbtu`
+- `annual_calculated_dhw_boiler_fuel_load_mmbtu` sum of the `dhw_boiler_fuel_load_series_mmbtu_per_hour`
+- `annual_calculated_space_heating_boiler_fuel_load_mmbtu` sum of the `space_heating_boiler_fuel_load_series_mmbtu_per_hour`
+- `annual_calculated_process_heat_boiler_fuel_load_mmbtu` sum of the `process_heat_boiler_fuel_load_series_mmbtu_per_hour`
+- `annual_calculated_total_heating_boiler_fuel_load_mmbtu` sum of the `total_heating_boiler_fuel_load_series_mmbtu_per_hour`
 """
 function add_heating_load_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
     # Adds the `ElectricLoad` results to the dictionary passed back from `run_reopt` using the solved model `m` and the `REoptInputs` for node `_n`.


### PR DESCRIPTION
### Added

- In `heating_cooling_load.jl`, Add new results `process_heat_thermal_load_series_mmbtu_per_hour`, `process_heat_boiler_fuel_load_series_mmbtu_per_hour`, `annual_calculated_process_heat_thermal_load_mmbtu`, and `annual_calculated_process_heat_boiler_fuel_load_mmbtu` to HeatingLoad results, with sum heating loads now including process heat 