### PR TITLE
Fix ghp-to-storage dispatch

### DIFF
--- a/src/constraints/storage_constraints.jl
+++ b/src/constraints/storage_constraints.jl
@@ -181,6 +181,19 @@ function add_hot_thermal_storage_dispatch_constraints(m, p, b; _n="")
         sum(m[Symbol("dvHeatFromStorage"*_n)][b,q,ts] for q in p.heating_loads)
     )
 
+    #Do not allow GHP to charge storage
+    if !isempty(p.techs.ghp)
+        for b in p.s.storage.types.hot
+            for t in p.techs.ghp
+                for q in p.heating_loads
+                    for ts in p.time_steps
+                        fix(m[Symbol("dvHeatToStorage"*_n)][b,t,q,ts], 0.0, force=true)
+                    end
+               end
+            end
+        end
+    end
+
 end
 
 function add_cold_thermal_storage_dispatch_constraints(m, p, b; _n="")
@@ -207,6 +220,17 @@ function add_cold_thermal_storage_dispatch_constraints(m, p, b; _n="")
         m[Symbol("dvStoragePower"*_n)][b] >= m[Symbol("dvDischargeFromStorage"*_n)][b,ts] + 
         sum(m[Symbol("dvProductionToStorage"*_n)][b,t,ts] for t in p.techs.cooling)
     )
+
+    #Do not allow GHP to charge storage
+    if !isempty(p.techs.ghp)
+        for b in p.s.storage.types.cold
+            for t in p.techs.ghp
+                for ts in p.time_steps
+                    fix(m[Symbol("dvProductionToStorage"*_n)][b,t,ts], 0.0, force=true)
+                end
+            end
+        end
+    end
 end
 
 function add_storage_sum_constraints(m, p; _n="")

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -584,7 +584,7 @@ function add_variables!(m::JuMP.AbstractModel, p::REoptInputs)
 		dvGridPurchase[p.time_steps, 1:p.s.electric_tariff.n_energy_tiers] >= 0  # Power from grid dispatched to meet electrical load [kW]
 		dvRatedProduction[p.techs.all, p.time_steps] >= 0  # Rated production of technology t [kW]
 		dvCurtail[p.techs.all, p.time_steps] >= 0  # [kW]
-		dvProductionToStorage[p.s.storage.types.all, p.techs.all, p.time_steps] >= 0  # Power from technology t used to charge storage system b [kW]
+		dvProductionToStorage[p.s.storage.types.all, union(p.techs.ghp,p.techs.all), p.time_steps] >= 0  # Power from technology t used to charge storage system b [kW]
 		dvDischargeFromStorage[p.s.storage.types.all, p.time_steps] >= 0 # Power discharged from storage system b [kW]
 		dvGridToStorage[p.s.storage.types.elec, p.time_steps] >= 0 # Electrical power delivered to storage by the grid [kW]
 		dvStoredEnergy[p.s.storage.types.all, 0:p.time_steps[end]] >= 0  # State of charge of storage system b

--- a/test/scenarios/ghp_inputs.json
+++ b/test/scenarios/ghp_inputs.json
@@ -55,5 +55,15 @@
     "ElectricStorage": {
         "max_kw": 0.0,
         "max_kwh": 0.0
+    },
+    "ColdThermalStorage": {
+        "min_gal": 10,
+        "max_gal": 10,
+        "thermal_decay_rate_fraction": 0.0
+    },
+    "HotThermalStorage": {
+        "min_gal": 10,
+        "max_gal": 10,
+        "thermal_decay_rate_fraction": 0.0
     }
 }


### PR DESCRIPTION
- Prevents a bug in which the model fails to build when both GHP and thermal storage are present
- While decision variables are present for GHP to charge to storage, these are fixed to zero, i.e., GHP cannot charge storage (which is consistent with the original formulation for GHP; it only served load previously)