### PR TITLE
Error when non standard value for "units" field in "energyratestructure" of URDB response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ Classify the change according to the following categories:
 - When the URDB response `energyratestructure` has a "unit" value that is not "kWh", throw an error instead of averaging rates in each energy tier.
 ### Fixed
 - Updated the PV result **lifecycle_om_cost_after_tax** to account for the third-party factor for third-party ownership analyses.
-
-## Develop
-### Fixed
 - Convert `max_electric_load_kw` to _Float64_ before passing to function `get_chp_defaults_prime_mover_size_class`
 
 ## v0.46.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Classify the change according to the following categories:
 
 ## Develop
 ### Changed
-- When the URDB response `energyratestructure` has a "unit" value that is not "kWh", treat rates normally, assuming the units are kWh (don't average rates in each energy tier).
+- When the URDB response `energyratestructure` has a "unit" value that is not "kWh", throw an error instead of averaging rates in each energy tier.
 
 ## v0.46.1
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## Develop
+### Changed
+- When the URDB response `energyratestructure` has a "unit" value that is not "kWh", treat rates normally, assuming the units are kWh (don't average rates in each energy tier).
+
 ## v0.46.1
 ### Changed
 - Updated the GHP testset .json `./test/scenarios/ghp_inputs.json` to include a nominal HotThermalStorage and ColdThermalStorage system.

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -220,7 +220,6 @@ function parse_urdb_energy_costs(d::Dict, year::Int; time_steps_per_hour=1, bigM
     period_with_max_tiers = findall(energy_tiers .== maximum(energy_tiers))[1]
     n_energy_tiers = Int(maximum(energy_tier_set))
 
-    rates = Float64[]
     energy_tier_limits_kwh = Float64[]
 
     for energy_tier in d["energyratestructure"][period_with_max_tiers]
@@ -230,8 +229,6 @@ function parse_urdb_energy_costs(d::Dict, year::Int; time_steps_per_hour=1, bigM
         if "rate" in keys(energy_tier) || "adj" in keys(energy_tier)  || "sell" in keys(energy_tier)
             append!(energy_tier_limits_kwh, energy_tier_max)
         end
-
-        append!(rates, get(energy_tier, "rate", 0) + get(energy_tier, "adj", 0))
     end
 
     energy_cost_vector = Float64[]

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -222,7 +222,6 @@ function parse_urdb_energy_costs(d::Dict, year::Int; time_steps_per_hour=1, bigM
 
     rates = Float64[]
     energy_tier_limits_kwh = Float64[]
-    non_kwh_units = false
 
     for energy_tier in d["energyratestructure"][period_with_max_tiers]
         # energy_tier is a dictionary, eg. {'max': 1000, 'rate': 0.07531, 'adj': 0.0119, 'unit': 'kWh'}
@@ -232,18 +231,7 @@ function parse_urdb_energy_costs(d::Dict, year::Int; time_steps_per_hour=1, bigM
             append!(energy_tier_limits_kwh, energy_tier_max)
         end
 
-        if "unit" in keys(energy_tier) && string(energy_tier["unit"]) != "kWh"
-            @warn "Using average rate in tier due to exotic units of " energy_tier["unit"]
-            non_kwh_units = true
-        end
-
         append!(rates, get(energy_tier, "rate", 0) + get(energy_tier, "adj", 0))
-    end
-
-    if non_kwh_units
-        rate_average = sum(rates) / maximum([length(rates), 1])
-        n_energy_tiers = 1
-        energy_tier_limits_kwh = Float64[bigM]
     end
 
     energy_cost_vector = Float64[]
@@ -276,9 +264,7 @@ function parse_urdb_energy_costs(d::Dict, year::Int; time_steps_per_hour=1, bigM
                     else
                         tier_use = tier
                     end
-                    total_rate = non_kwh_units ? 
-                                rate_average : 
-                                (get(d["energyratestructure"][period][tier_use], "rate", 0) + 
+                    total_rate = (get(d["energyratestructure"][period][tier_use], "rate", 0) + 
                                 get(d["energyratestructure"][period][tier_use], "adj", 0)) 
                     sell = get(d["energyratestructure"][period][tier_use], "sell", 0)
 

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -229,10 +229,10 @@ function parse_urdb_energy_costs(d::Dict, year::Int; time_steps_per_hour=1, bigM
         if "rate" in keys(energy_tier) || "adj" in keys(energy_tier)  || "sell" in keys(energy_tier)
             append!(energy_tier_limits_kwh, energy_tier_max)
         end
-    end
 
-    if "unit" in keys(energy_tier) && string(energy_tier["unit"]) != "kWh"
-        throw(@error("URDB energy tiers have exotic units of " * energy_tier["unit"]))
+        if "unit" in keys(energy_tier) && string(energy_tier["unit"]) != "kWh"
+            throw(@error("URDB energy tiers have exotic units of " * energy_tier["unit"]))
+        end
     end
 
     energy_cost_vector = Float64[]

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -231,6 +231,10 @@ function parse_urdb_energy_costs(d::Dict, year::Int; time_steps_per_hour=1, bigM
         end
     end
 
+    if "unit" in keys(energy_tier) && string(energy_tier["unit"]) != "kWh"
+        throw(@error("URDB energy tiers have exotic units of " * energy_tier["unit"]))
+    end
+
     energy_cost_vector = Float64[]
     sell_vector = Float64[]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1206,6 +1206,16 @@ else  # run HiGHS tests
             # inputs = REoptInputs(s)
             # results = run_reopt(m, inputs)
 
+            @testset "Exotic Units for Energy Rates" begin
+                d = JSON.parsefile("./scenarios/no_techs.json")
+                d["ElectricTariff"] = Dict(
+                    "urdb_label" => "6272e4ae7eb76766c247d469"
+                )
+                m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
+                results = run_reopt(m, d)
+                @test occursin("URDB energy tiers have exotic units of", string(results["Messages"]))
+            end
+
         end
 
         @testset "EASIUR" begin


### PR DESCRIPTION
### Changed
- When the URDB response `energyratestructure` has a "unit" value that is not "kWh", throw an error instead of averaging rates in each energy tier.