### PR TITLE
tax rate alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## Develop 
+### Changed 
+- Changed default Financial **owner_tax_rate_fraction** and **oftaker_tax_rate_fraction** from 0.257 to 0.26 to align with API and user manual defaults. 
+
 ## v0.46.2
 ### Changed
 - When the URDB response `energyratestructure` has a "unit" value that is not "kWh", throw an error instead of averaging rates in each energy tier.

--- a/src/core/financial.jl
+++ b/src/core/financial.jl
@@ -82,10 +82,10 @@ struct Financial
         boiler_fuel_cost_escalation_rate_fraction::Real = 0.015,
         chp_fuel_cost_escalation_rate_fraction::Real = 0.015,
         generator_fuel_cost_escalation_rate_fraction::Real = 0.012,
-        offtaker_tax_rate_fraction::Real = 0.257,
+        offtaker_tax_rate_fraction::Real = 0.26,
         offtaker_discount_rate_fraction::Real = 0.0638,
         third_party_ownership::Bool = false,
-        owner_tax_rate_fraction::Real = 0.257,
+        owner_tax_rate_fraction::Real = 0.26,
         owner_discount_rate_fraction::Real = 0.0638,
         analysis_years::Int = 25,
         value_of_lost_load_per_kwh::Union{Array{<:Real,1}, Real} = 1.00, #only applies to multiple outage modeling


### PR DESCRIPTION
### Changed 
- Changed default Financial **owner_tax_rate_fraction** and **oftaker_tax_rate_fraction** from 0.257 to 0.26 to align with API and user manual defaults. 

I think this had previously been updated in the annual updates sweep because the ATB lists 25.7%, but we round this up to 26% in the user manual defaults section (and the REopt.jl help text, API, and web tool are all currently showing 26%). 