### PR TITLE
Hot Fix: Monthly input for cooling, and simulated_load heating

### DIFF
--- a/src/core/doe_commercial_reference_building_loads.jl
+++ b/src/core/doe_commercial_reference_building_loads.jl
@@ -105,16 +105,27 @@ end
 
 
 """
-    built_in_load(type::String, city::String, buildingtype::String, 
-        year::Int, annual_energy::Real, monthly_energies::AbstractArray{<:Real,1}
-        boiler_efficiency_input::Union{Real,Nothing}=nothing
+    built_in_load(
+        type::String, 
+        city::String, 
+        buildingtype::String, 
+        year::Int, 
+        annual_energy::Real, 
+        monthly_energies::AbstractArray{<:Real,1},
+        boiler_efficiency_input::Union{Real,Nothing}=nothing        
     )
 Scale a normalized Commercial Reference Building according to inputs provided and return the 8760.
 """
 
-function built_in_load(type::String, city::String, buildingtype::String, 
-    year::Int, annual_energy::R, monthly_energies::AbstractArray{R,1},
-    boiler_efficiency_input::Union{R,Nothing}=nothing) where {R <: Real}
+function built_in_load(
+    type::String, 
+    city::String, 
+    buildingtype::String, 
+    year::Int, 
+    annual_energy::Real, 
+    monthly_energies::AbstractArray{<:Real,1},
+    boiler_efficiency_input::Union{Real,Nothing}=nothing
+    )
 
     @assert type in ["electric", "domestic_hot_water", "space_heating", "cooling", "process_heat"]
     monthly_scalers = ones(12)

--- a/src/core/simulated_load.jl
+++ b/src/core/simulated_load.jl
@@ -452,12 +452,12 @@ function simulated_load(d::Dict)
                                     existing_boiler_efficiency=boiler_efficiency
                                 )
 
-        load_series = heating_load.loads_kw ./ boiler_efficiency ./ KWH_PER_MMBTU
+        load_series = heating_load.loads_kw ./ boiler_efficiency ./ KWH_PER_MMBTU  # [MMBtu/hr fuel]
         heating_monthly_energy = get_monthly_energy(load_series)
     
         response = Dict([
             ("loads_mmbtu_per_hour", round.(load_series, digits=3)),
-            ("annual_mmbtu", round(heating_load.annual_mmbtu, digits=3)),
+            ("annual_mmbtu", round(sum(load_series), digits=3)),
             ("monthly_mmbtu", round.(heating_monthly_energy, digits=3)),
             ("min_mmbtu_per_hour", round(minimum(load_series), digits=3)),
             ("mean_mmbtu_per_hour", round(sum(load_series) / length(load_series), digits=3)),


### PR DESCRIPTION
- Fix array element type for `built_in_load()` field `monthly_energies` to be `<:Real`, where before the `where` feature was not applying `<:Real` correctly.
- Revert the formatting of `built_in_load()` back to single argument on each line.
- Fix `simulated_load()` heating load response field `annual_mmbtu` to fuel instead of thermal, for individual heating `load_types`