### PR TITLE
Add JuMP error message when non-optimal (typ infeasible)

### DIFF
--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -145,15 +145,21 @@ function run_reopt(ms::AbstractArray{T, 1}, p::REoptInputs) where T <: JuMP.Abst
 			rs[i] = run_reopt(inputs[i])
 		end
 		if typeof(rs[1]) <: Dict && typeof(rs[2]) <: Dict && rs[1]["status"] != "error" && rs[2]["status"] != "error"
-			# TODO when a model is infeasible the JuMP.Model is returned from run_reopt (and not the results Dict)
-			results_dict = combine_results(p, rs[1], rs[2], bau_inputs.s)
+			# TODO when a model is infeasible the JuMP.Model is returned from run_reopt (and not the results Dict)        
+            results_dict = combine_results(p, rs[1], rs[2], bau_inputs.s)
 			results_dict["Financial"] = merge(results_dict["Financial"], proforma_results(p, results_dict))
 			if !isempty(p.techs.pv)
 				organize_multiple_pv_results(p, results_dict)
 			end
 			return results_dict
 		else
-			throw(@error("REopt scenarios solved either with errors or non-optimal solutions."))
+			extra_details = []
+			if rs[1]["status"] == "error"  # First check if BAU has error
+				extra_details = rs[1]["Messages"]["errors"][1][1]
+			elseif rs[2]["status"] == "error"  # If no BAU error, check Optimal error
+				extra_details = rs[2]["Messages"]["errors"][1][1]
+			end			
+			throw(@error("REopt scenarios solved either with errors or non-optimal solutions. Additional details: "*extra_details*"."))
 		end
 	catch e
 		if isnothing(e) # Error thrown by REopt


### PR DESCRIPTION
Currently only add first entry of the message which is typically the most informative and human readable.