### PR TITLE
Improve GitHub Actions Behavior

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.8']
         julia-arch: [x64]
-        os: [ubuntu-latest, windows-latest, macOS-13]
+        os: [windows-latest, macOS-13]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.8']
         julia-arch: [x64]
-        os: [windows-latest, macOS-13]
+        os: [ubuntu-latest, windows-latest, macOS-13]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.8']
         julia-arch: [x64]
-        os: [windows-latest, macOS-13]
+        os: [windows-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.8']
         julia-arch: [x64]
-        # os: [ubuntu-latest, windows-latest, macOS-11]
-        os: [windows-latest, macOS-11]
+        os: [windows-latest, macOS-13]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## Develop 08-09-2024
+### Changed
+- Removed MacOS from the runner list and just run with Windows OS, since MacOS commonly freezes and gets cancelled. We have not seen Windows OS pass while other OS's fail. .
+- Suppress JuMP warning messages from 15-minute and multiple PVs test scenarios to avoid flooding the test logs with those warnings 
+
 ## v0.47.2
 ### Fixed
 - Increased the big-M bound on maximum net metering benefit to prevent artificially low export benefits.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1312,24 +1312,27 @@ else  # run HiGHS tests
         end
 
         @testset "Multiple PVs" begin
-            m1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
-            m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
-            results = run_reopt([m1,m2], "./scenarios/multiple_pvs.json")
+            logger = SimpleLogger()
+            with_logger(logger) do
+                m1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
+                m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
+                results = run_reopt([m1,m2], "./scenarios/multiple_pvs.json")
 
-            ground_pv = results["PV"][findfirst(pv -> pv["name"] == "ground", results["PV"])]
-            roof_west = results["PV"][findfirst(pv -> pv["name"] == "roof_west", results["PV"])]
-            roof_east = results["PV"][findfirst(pv -> pv["name"] == "roof_east", results["PV"])]
+                ground_pv = results["PV"][findfirst(pv -> pv["name"] == "ground", results["PV"])]
+                roof_west = results["PV"][findfirst(pv -> pv["name"] == "roof_west", results["PV"])]
+                roof_east = results["PV"][findfirst(pv -> pv["name"] == "roof_east", results["PV"])]
 
-            @test ground_pv["size_kw"] ≈ 15 atol=0.1
-            @test roof_west["size_kw"] ≈ 7 atol=0.1
-            @test roof_east["size_kw"] ≈ 4 atol=0.1
-            @test ground_pv["lifecycle_om_cost_after_tax_bau"] ≈ 782.0 atol=0.1
-            @test roof_west["lifecycle_om_cost_after_tax_bau"] ≈ 782.0 atol=0.1
-            @test ground_pv["annual_energy_produced_kwh_bau"] ≈ 8933.09 atol=0.1
-            @test roof_west["annual_energy_produced_kwh_bau"] ≈ 7656.11 atol=0.1
-            @test ground_pv["annual_energy_produced_kwh"] ≈ 26799.26 atol=0.1
-            @test roof_west["annual_energy_produced_kwh"] ≈ 10719.51 atol=0.1
-            @test roof_east["annual_energy_produced_kwh"] ≈ 6685.95 atol=0.1
+                @test ground_pv["size_kw"] ≈ 15 atol=0.1
+                @test roof_west["size_kw"] ≈ 7 atol=0.1
+                @test roof_east["size_kw"] ≈ 4 atol=0.1
+                @test ground_pv["lifecycle_om_cost_after_tax_bau"] ≈ 782.0 atol=0.1
+                @test roof_west["lifecycle_om_cost_after_tax_bau"] ≈ 782.0 atol=0.1
+                @test ground_pv["annual_energy_produced_kwh_bau"] ≈ 8933.09 atol=0.1
+                @test roof_west["annual_energy_produced_kwh_bau"] ≈ 7656.11 atol=0.1
+                @test ground_pv["annual_energy_produced_kwh"] ≈ 26799.26 atol=0.1
+                @test roof_west["annual_energy_produced_kwh"] ≈ 10719.51 atol=0.1
+                @test roof_east["annual_energy_produced_kwh"] ≈ 6685.95 atol=0.1
+            end
         end
 
         @testset "Thermal Energy Storage + Absorption Chiller" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using DotEnv
 DotEnv.load!()
 using Random
 using DelimitedFiles
+using Logging
 Random.seed!(42)
 
 if "Xpress" in ARGS
@@ -1207,15 +1208,18 @@ else  # run HiGHS tests
                 @test results["PV"]["size_kw"] ≈ p.max_sizes["PV"]
             end
 
-            # Temporarily skip this test which is flooding our test logs with warnings
-            # @testset "Custom URDB with Sub-Hourly" begin
-            #     # Testing a 15-min post with a urdb_response with multiple n_energy_tiers
-            #     model = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
-            #     p = REoptInputs("./scenarios/subhourly_with_urdb.json")
-            #     results = run_reopt(model, p)
-            #     @test length(p.s.electric_tariff.export_rates[:WHL]) ≈ 8760*4
-            #     @test results["PV"]["size_kw"] ≈ p.s.pvs[1].existing_kw
-            # end
+            @testset "Custom URDB with Sub-Hourly" begin
+                # Avoid excessive JuMP warning messages about += with Expressions
+                logger = SimpleLogger()
+                with_logger(logger) do
+                    # Testing a 15-min post with a urdb_response with multiple n_energy_tiers
+                    model = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
+                    p = REoptInputs("./scenarios/subhourly_with_urdb.json")
+                    results = run_reopt(model, p)
+                    @test length(p.s.electric_tariff.export_rates[:WHL]) ≈ 8760*4
+                    @test results["PV"]["size_kw"] ≈ p.s.pvs[1].existing_kw
+                end
+            end
 
             @testset "Multi-tier demand and energy rates" begin
                 #This test ensures that when multiple energy or demand regimes are included, that the tier limits load appropriately

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1207,14 +1207,15 @@ else  # run HiGHS tests
                 @test results["PV"]["size_kw"] ≈ p.max_sizes["PV"]
             end
 
-            @testset "Custom URDB with Sub-Hourly" begin
-                # Testing a 15-min post with a urdb_response with multiple n_energy_tiers
-                model = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
-                p = REoptInputs("./scenarios/subhourly_with_urdb.json")
-                results = run_reopt(model, p)
-                @test length(p.s.electric_tariff.export_rates[:WHL]) ≈ 8760*4
-                @test results["PV"]["size_kw"] ≈ p.s.pvs[1].existing_kw
-            end
+            # Temporarily skip this test which is flooding our test logs with warnings
+            # @testset "Custom URDB with Sub-Hourly" begin
+            #     # Testing a 15-min post with a urdb_response with multiple n_energy_tiers
+            #     model = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
+            #     p = REoptInputs("./scenarios/subhourly_with_urdb.json")
+            #     results = run_reopt(model, p)
+            #     @test length(p.s.electric_tariff.export_rates[:WHL]) ≈ 8760*4
+            #     @test results["PV"]["size_kw"] ≈ p.s.pvs[1].existing_kw
+            # end
 
             @testset "Multi-tier demand and energy rates" begin
                 #This test ensures that when multiple energy or demand regimes are included, that the tier limits load appropriately


### PR DESCRIPTION
- After updating MacOS runner to 13 because the previously used 11 was recently deprecated by GitHub Actions, and seeing that it does **occasionally** run, it's still way to intermittent/finicky. I'm proposing that we remove MacOS from the runner list and just run with Windows OS. 
  - Until we start seeing different test behavior across different OS's (I don't think we have), I think it's safe to stick to the one type of runner that's working for us (Windows).
- Suppress JuMP warning messages from 15-minute and multiple PVs test scenarios
  - To avoid flooding the test logs with those warnings 