### PR TITLE
Enable tracking of REopt.jl runs with PV and Wind from api.data.gov

### DIFF
--- a/src/core/production_factor.jl
+++ b/src/core/production_factor.jl
@@ -72,7 +72,7 @@ function get_production_factor(wind::Wind, latitude::Real, longitude::Real, time
             resource = []
             try
                 @info "Querying Wind Toolkit for resource data ..."
-                r = HTTP.get(url; retries=5)
+                r = HTTP.get(url, ["User-Agent" => "REopt.jl"]; retries=5)
                 if r.status != 200
                     throw(@error("Bad response from Wind Toolkit: $(response["errors"])"))
                 end

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -461,7 +461,7 @@ function call_pvwatts_api(latitude::Real, longitude::Real; tilt=latitude, azimut
 
     try
         @info "Querying PVWatts for production factor and ambient air temperature... "
-        r = HTTP.get(url, keepalive=true, readtimeout=10)
+        r = HTTP.get(url, ["User-Agent" => "REopt.jl"]; keepalive=true, readtimeout=10)
         response = JSON.parse(String(r.body))
         if r.status != 200
             throw(@error("Bad response from PVWatts: $(response["errors"])"))


### PR DESCRIPTION
- Add header User-Agent=REopt.jl to PVWatts and Wind Toolkit API requests
  - This enables tracking of REopt.jl usage from within the api.data.gov platform, with admin monitoring access to the PVWatts and Wind Toolkit API's on api.data.gov
  - (Suggestion by Nick Muerdter for quick ability to track, including by user from the user's API key, even if for only when the users are using the PVWatts or Wind Toolkit APIs for production factor)