### PR TITLE
Fix proforma for thermal techs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Classify the change according to the following categories:
 
 ## Develop 08-09-2024
 ### Added
-- Ouput which has "net year one" CapEx after incentives except for MACRS, which helps with users defining their own "simple payback period"
+- Financial output **net_capital_costs_without_macrs** which has "net year one" CapEx after incentives except for MACRS, which helps with users defining their own "simple payback period"
 ### Changed
 - Improve the full test suite reporting with a verbose summary table, and update the structure to reflect long-term open-source solver usage.
 - Removed MacOS from the runner list and just run with Windows OS, since MacOS commonly freezes and gets cancelled. We have not seen Windows OS pass while other OS's fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ Classify the change according to the following categories:
 ## Develop 08-09-2024
 ### Changed
 - Removed MacOS from the runner list and just run with Windows OS, since MacOS commonly freezes and gets cancelled. We have not seen Windows OS pass while other OS's fail. .
-- Suppress JuMP warning messages from 15-minute and multiple PVs test scenarios to avoid flooding the test logs with those warnings 
+- Suppress JuMP warning messages from 15-minute and multiple PVs test scenarios to avoid flooding the test logs with those warnings
+- Updated/specified User-Agent header of "REopt.jl" for PVWatts and Wind Toolkit API requests; default before was "HTTP.jl"; this allows specific tracking of REopt.jl usage which call PVWatts and Wind Toolkit through api.data.gov.
 
 ## v0.47.2
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Classify the change according to the following categories:
     ### Removed
 
 ## Develop 08-09-2024
+### Added
+- Ouput which has "net year one" CapEx after incentives except for MACRS, which helps with users defining their own "simple payback period"
 ### Changed
 - Improve the full test suite reporting with a verbose summary table, and update the structure to reflect long-term open-source solver usage.
 - Removed MacOS from the runner list and just run with Windows OS, since MacOS commonly freezes and gets cancelled. We have not seen Windows OS pass while other OS's fail.

--- a/src/core/reopt_inputs.jl
+++ b/src/core/reopt_inputs.jl
@@ -396,8 +396,8 @@ function setup_tech_inputs(s::AbstractScenario)
     end
 
     if "Boiler" in techs.all
-        setup_boiler_inputs(s, max_sizes, min_sizes, existing_sizes, cap_cost_slope, 
-            boiler_efficiency, production_factor, fuel_cost_per_kwh)
+        setup_boiler_inputs(s, max_sizes, min_sizes, existing_sizes, cap_cost_slope, boiler_efficiency,
+            om_cost_per_kw, production_factor, fuel_cost_per_kwh)
     end
 
     if "CHP" in techs.all
@@ -693,14 +693,16 @@ end
 
 """
     function setup_boiler_inputs(s::AbstractScenario, max_sizes, min_sizes, existing_sizes, cap_cost_slope, boiler_efficiency,
-        production_factor, fuel_cost_per_kwh)
+        om_cost_per_kw, production_factor, fuel_cost_per_kwh)
 
 Update tech-indexed data arrays necessary to build the JuMP model with the values for (new) boiler.
 This version of this function, used in BAUInputs(), doesn't update renewable energy and emissions arrays.
 """
-function setup_boiler_inputs(s::AbstractScenario, max_sizes, min_sizes, cap_cost_slope, om_cost_per_kw, boiler_efficiency, production_factor, fuel_cost_per_kwh)
+function setup_boiler_inputs(s::AbstractScenario, max_sizes, min_sizes, existing_sizes, cap_cost_slope, boiler_efficiency,
+                            om_cost_per_kw, production_factor, fuel_cost_per_kwh)
     max_sizes["Boiler"] = s.boiler.max_kw
     min_sizes["Boiler"] = s.boiler.min_kw
+    existing_sizes["Boiler"] = 0.0
     boiler_efficiency["Boiler"] = s.boiler.efficiency
     
     # The Boiler only has a MACRS benefit, no ITC etc.

--- a/src/results/existing_boiler.jl
+++ b/src/results/existing_boiler.jl
@@ -18,7 +18,7 @@
 """
 function add_existing_boiler_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
     r = Dict{String, Any}()
-
+    r["size_mmbtu_per_hour"] = round(value(m[Symbol("dvSize"*_n)]["ExistingBoiler"]) / KWH_PER_MMBTU, digits=3)
 	r["fuel_consumption_series_mmbtu_per_hour"] = 
         round.(value.(m[:dvFuelUsage]["ExistingBoiler", ts] for ts in p.time_steps) ./ KWH_PER_MMBTU, digits=5)
     r["annual_fuel_consumption_mmbtu"] = round(sum(r["fuel_consumption_series_mmbtu_per_hour"]), digits=5)

--- a/src/results/existing_boiler.jl
+++ b/src/results/existing_boiler.jl
@@ -1,6 +1,7 @@
 # REopt®, Copyright (c) Alliance for Sustainable Energy, LLC. See also https://github.com/NREL/REopt.jl/blob/master/LICENSE.
 """
 `ExistingBoiler` results keys:
+- `size_mmbtu_per_hour`
 - `fuel_consumption_series_mmbtu_per_hour` 
 - `annual_fuel_consumption_mmbtu`
 - `thermal_production_series_mmbtu_per_hour`

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -334,7 +334,7 @@ end
 Get the depreciation schedule for MACRS. First check if tech.macrs_option_years in [5 ,7], then call function to return depreciation schedule
 Used in results/financial.jl and results/proformal.jl multiple times
 """
-function get_depreciation_schedule(p::REoptInputs, tech::AbstractTech, federal_itc_basis::Float64=0.0)
+function get_depreciation_schedule(p::REoptInputs, tech::Union{AbstractTech,AbstractStorage}, federal_itc_basis::Float64=0.0)
     schedule = []
     if tech.macrs_option_years == 5
         schedule = p.s.financial.macrs_five_year

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -161,34 +161,17 @@ function initial_capex(m::JuMP.AbstractModel, p::REoptInputs; _n="")
     end
 
     if "CHP" in p.techs.all
-        # CHP.installed_cost_per_kw is now a list with potentially > 1 elements
-        cost_list = p.s.chp.installed_cost_per_kw
-        size_list = p.s.chp.tech_sizes_for_cost_curve
-        chp_size = value.(m[Symbol("dvPurchaseSize"*_n)])["CHP"]
-        if typeof(cost_list) == Vector{Float64}
-            if chp_size <= size_list[1]
-                initial_capex += chp_size * cost_list[1]  # Currently not handling non-zero cost ($) for 0 kW size input
-            elseif chp_size > size_list[end]
-                initial_capex += chp_size * cost_list[end]
-            else
-                for s in 2:length(size_list)
-                    if (chp_size > size_list[s-1]) && (chp_size <= size_list[s])
-                        slope = (cost_list[s] * size_list[s] - cost_list[s-1] * size_list[s-1]) /
-                                (size_list[s] - size_list[s-1])
-                        initial_capex += cost_list[s-1] * size_list[s-1] + (chp_size - size_list[s-1]) * slope
-                    end
-                end
-            end
-        else
-            initial_capex += cost_list * chp_size
-        #Add supplementary firing capital cost
-        # chp_supp_firing_size = self.nested_outputs["Scenario"]["Site"][tech].get("size_supplementary_firing_kw")
-        # chp_supp_firing_cost = self.inputs[tech].get("supplementary_firing_capital_cost_per_kw") or 0
-        # initial_capex += chp_supp_firing_size * chp_supp_firing_cost
-        end
+        chp_size_kw = value.(m[Symbol("dvPurchaseSize"*_n)])["CHP"]
+        initial_capex += get_chp_initial_capex(p, chp_size_kw)
     end
 
-    # TODO thermal tech costs
+    if "Boiler" in p.techs.all
+        initial_capex += p.s.boiler.installed_cost_per_kw * value.(m[Symbol("dvPurchaseSize"*_n)])["Boiler"]
+    end
+
+    if "AbsorptionChiller" in p.techs.all
+        initial_capex += p.s.absorption_chiller.installed_cost_per_kw * value.(m[Symbol("dvPurchaseSize"*_n)])["AbsorptionChiller"]
+    end
 
     if !isempty(p.s.ghp_option_list)
 
@@ -325,21 +308,10 @@ function calculate_lcoe(p::REoptInputs, tech_results::Dict, tech::AbstractTech)
     federal_itc_amount = tech.federal_itc_fraction * federal_itc_basis
     npv_federal_itc = federal_itc_amount * (1.0/(1.0+discount_rate_fraction))
 
-    depreciation_schedule = zeros(years)
-    if tech.macrs_option_years in [5,7]
-        if tech.macrs_option_years == 5
-            schedule = p.s.financial.macrs_five_year
-        elseif tech.macrs_option_years == 7
-            schedule = p.s.financial.macrs_seven_year
-        end
-        macrs_bonus_basis = federal_itc_basis - (federal_itc_basis * tech.federal_itc_fraction * tech.macrs_itc_reduction)
-        macrs_basis = macrs_bonus_basis * (1 - tech.macrs_bonus_fraction)
-        for (i,r) in enumerate(schedule)
-            if i-1 < length(depreciation_schedule)
-                depreciation_schedule[i] = macrs_basis * r
-            end
-        end
-        depreciation_schedule[1] += tech.macrs_bonus_fraction * macrs_bonus_basis
+    if tech.macrs_option_years in [5 ,7]
+        depreciation_schedule = get_depreciation_schedule(p, tech, federal_itc_basis)
+    else
+        depreciation_schedule = zeros(years)
     end
 
     tax_deductions = (om_series + depreciation_schedule) * federal_tax_rate_fraction
@@ -354,4 +326,76 @@ function calculate_lcoe(p::REoptInputs, tech_results::Dict, tech::AbstractTech)
     lcoe = (capital_costs + npv_om - npv_pbi - cbi - ibi - npv_federal_itc - npv_tax_deductions ) / npv_annual_energy
 
     return round(lcoe, digits=4)
+end
+
+"""
+    get_depreciation_schedule(p::REoptInputs, tech::AbstractTech, federal_itc_basis::Float64=0.0)
+
+Get the depreciation schedule for MACRS. First check if tech.macrs_option_years in [5 ,7], then call function to return depreciation schedule
+Used in results/financial.jl and results/proformal.jl multiple times
+"""
+function get_depreciation_schedule(p::REoptInputs, tech::AbstractTech, federal_itc_basis::Float64=0.0)
+    schedule = []
+    if tech.macrs_option_years == 5
+        schedule = p.s.financial.macrs_five_year
+    elseif tech.macrs_option_years == 7
+        schedule = p.s.financial.macrs_seven_year
+    end
+
+    federal_itc_fraction = 0.0
+    try 
+        federal_itc_fraction = tech.federal_itc_fraction
+    catch
+        @warn "did not find tech.federal_itc_fraction so using 0.0"
+    end
+    
+    macrs_bonus_basis = federal_itc_basis - federal_itc_basis * federal_itc_fraction * tech.macrs_itc_reduction
+    macrs_basis = macrs_bonus_basis * (1 - tech.macrs_bonus_fraction)
+
+    depreciation_schedule = zeros(p.s.financial.analysis_years)
+    for (i, r) in enumerate(schedule)
+        if i < length(depreciation_schedule)
+            depreciation_schedule[i] = macrs_basis * r
+        end
+    end
+    depreciation_schedule[1] += (tech.macrs_bonus_fraction * macrs_bonus_basis)
+
+    return depreciation_schedule
+end
+
+
+""" 
+    get_chp_initial_capex(p::REoptInputs, size_kw::Float64)
+
+CHP has a cost-curve input option, so calculating the initial CapEx requires more logic than typical tech CapEx calcs
+"""
+function get_chp_initial_capex(p::REoptInputs, size_kw::Float64)
+    # CHP.installed_cost_per_kw is now a list with potentially > 1 elements
+    cost_list = p.s.chp.installed_cost_per_kw
+    size_list = p.s.chp.tech_sizes_for_cost_curve
+    chp_size = size_kw
+    initial_capex = 0.0
+    if typeof(cost_list) == Vector{Float64}
+        if chp_size <= size_list[1]
+            initial_capex = chp_size * cost_list[1]  # Currently not handling non-zero cost ($) for 0 kW size input
+        elseif chp_size > size_list[end]
+            initial_capex = chp_size * cost_list[end]
+        else
+            for s in 2:length(size_list)
+                if (chp_size > size_list[s-1]) && (chp_size <= size_list[s])
+                    slope = (cost_list[s] * size_list[s] - cost_list[s-1] * size_list[s-1]) /
+                            (size_list[s] - size_list[s-1])
+                    initial_capex = cost_list[s-1] * size_list[s-1] + (chp_size - size_list[s-1]) * slope
+                end
+            end
+        end
+    else
+        initial_capex = cost_list * chp_size
+    #Add supplementary firing capital cost
+    # chp_supp_firing_size = self.nested_outputs["Scenario"]["Site"][tech].get("size_supplementary_firing_kw")
+    # chp_supp_firing_cost = self.inputs[tech].get("supplementary_firing_capital_cost_per_kw") or 0
+    # initial_capex += chp_supp_firing_size * chp_supp_firing_cost
+    end
+
+    return initial_capex
 end

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -165,6 +165,10 @@ function initial_capex(m::JuMP.AbstractModel, p::REoptInputs; _n="")
         initial_capex += get_chp_initial_capex(p, chp_size_kw)
     end
 
+    if "SteamTurbine" in p.techs.all
+        initial_capex += p.s.steam_turbine.installed_cost_per_kw * value.(m[Symbol("dvPurchaseSize"*_n)])["SteamTurbine"]
+    end
+
     if "Boiler" in p.techs.all
         initial_capex += p.s.boiler.installed_cost_per_kw * value.(m[Symbol("dvPurchaseSize"*_n)])["Boiler"]
     end

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -273,10 +273,10 @@ function calculate_lcoe(p::REoptInputs, tech_results::Dict, tech::AbstractTech)
 
     capital_costs = new_kw * tech.installed_cost_per_kw # pre-incentive capital costs
 
-    annual_om = new_kw * tech.om_cost_per_kw # NPV of O&M charges escalated over financial life
+    annual_om = new_kw * tech.om_cost_per_kw 
 
     om_series = [annual_om * (1+p.s.financial.om_cost_escalation_rate_fraction)^yr for yr in 1:years]
-    npv_om = sum([om * (1.0/(1.0+discount_rate_fraction))^yr for (yr, om) in enumerate(om_series)])
+    npv_om = sum([om * (1.0/(1.0+discount_rate_fraction))^yr for (yr, om) in enumerate(om_series)]) # NPV of O&M charges escalated over financial life
 
     #Incentives as calculated in the spreadsheet, note utility incentives are applied before state incentives
     utility_ibi = min(capital_costs * tech.utility_ibi_fraction, tech.utility_ibi_max)
@@ -350,7 +350,7 @@ function get_depreciation_schedule(p::REoptInputs, tech::Union{AbstractTech,Abst
     try 
         federal_itc_fraction = tech.federal_itc_fraction
     catch
-        @warn "did not find tech.federal_itc_fraction so using 0.0"
+        @warn "Did not find $(tech).federal_itc_fraction so using 0.0 in calculation of depreciation_schedule."
     end
     
     macrs_bonus_basis = federal_itc_basis - federal_itc_basis * federal_itc_fraction * tech.macrs_itc_reduction

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -105,6 +105,7 @@ function proforma_results(p::REoptInputs, d::Dict)
         if p.s.generator.existing_kw > 0
             fixed_and_var_om_bau = d["Generator"]["year_one_fixed_om_cost_before_tax_bau"] + 
                                    d["Generator"]["year_one_variable_om_cost_before_tax_bau"]
+            fixed_and_var_om -= fixed_and_var_om_bau
             year_one_fuel_cost_bau = d["Generator"]["year_one_fuel_cost_before_tax_bau"]
         end
 
@@ -253,10 +254,10 @@ function proforma_results(p::REoptInputs, d::Dict)
         annual_income_from_host_series = repeat([-1 * r["annualized_payment_to_third_party"]], years)
 
         r["offtaker_annual_free_cashflows"] = append!([0.0], 
-            electricity_bill_series + export_credit_series + m.fuel_cost_series + annual_income_from_host_series
+            electricity_bill_series + export_credit_series + m.fuel_cost_series + annual_income_from_host_series + m.om_series_bau
         )
         r["offtaker_annual_free_cashflows_bau"] = append!([0.0], 
-            electricity_bill_series_bau + export_credit_series_bau + m.fuel_cost_series_bau
+            electricity_bill_series_bau + export_credit_series_bau + m.fuel_cost_series_bau + m.om_series_bau
             )
 
     else  # get cumulative cashflow for offtaker

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -48,6 +48,7 @@ function proforma_results(p::REoptInputs, d::Dict)
     years = p.s.financial.analysis_years
     escalate_elec(val) = [-1 * val * (1 + p.s.financial.elec_cost_escalation_rate_fraction)^yr for yr in 1:years]
     escalate_om(val) = [val * (1 + p.s.financial.om_cost_escalation_rate_fraction)^yr for yr in 1:years]
+    escalate_fuel(val, esc_rate) = [val * (1 + esc_rate)^yr for yr in 1:years]
     third_party = p.s.financial.third_party_ownership
     
     # Create placeholder variables to store summed totals across all relevant techs
@@ -111,6 +112,7 @@ function proforma_results(p::REoptInputs, d::Dict)
         # In the two party case the developer does not include the fuel cost in their costs
         # It is assumed that the offtaker will pay for this at a rate that is not marked up
         # to cover developer profits
+        # TODO escalate fuel cost with p.s.financial.generator_fuel_cost_escalation_rate_fraction
         fixed_and_var_om = d["Generator"]["year_one_fixed_om_cost_before_tax"] + d["Generator"]["year_one_variable_om_cost_before_tax"]
         fixed_and_var_om_bau = 0.0
         year_one_fuel_cost_bau = 0.0
@@ -132,6 +134,64 @@ function proforma_results(p::REoptInputs, d::Dict)
         m.om_series += escalate_om(annual_om)
         m.om_series_bau += escalate_om(annual_om_bau)
     end
+
+    # calculate CHP o+m costs, incentives, and depreciation
+    if "CHP" in keys(d) && d["CHP"]["size_kw"] > 0
+        update_metrics(m, p, p.s.chp, "CHP", d, third_party)
+    end
+
+    # calculate (new) Boiler o+m costs (just fuel, no non-fuel operating costs currently)
+    # the optional installed_cost inputs assume net present cost so no option for MACRS or incentives
+    if "ExistingBoiler" in keys(d) && d["ExistingBoiler"]["size_mmbtu_per_hour"] > 0
+        fuel_cost = d["ExistingBoiler"]["year_one_fuel_cost_before_tax"]
+        m.om_series += escalate_fuel(-1 * fuel_cost, p.s.financial.existing_boiler_fuel_cost_escalation_rate_fraction)
+        var_om = 0.0
+        fixed_om = 0.0
+        annual_om = -1 * (var_om + fixed_om)
+        m.om_series += escalate_om(annual_om)
+        
+        # BAU ExistingBoiler
+        fuel_cost_bau = d["ExistingBoiler"]["year_one_fuel_cost_before_tax_bau"]
+        m.om_series_bau += escalate_fuel(-1 * fuel_cost_bau, p.s.financial.existing_boiler_fuel_cost_escalation_rate_fraction)
+        var_om_bau = 0.0
+        fixed_om_bau = 0.0
+        annual_om_bau = -1 * (var_om_bau + fixed_om_bau)
+        m.om_series_bau += escalate_om(annual_om_bau)
+
+    
+    end    
+
+    # calculate (new) Boiler o+m costs and depreciation (no incentives currently)
+    if "Boiler" in keys(d) && d["Boiler"]["size_mmbtu_per_hour"] > 0
+        fuel_cost = d["Boiler"]["year_one_fuel_cost_before_tax"]
+        m.om_series += escalate_fuel(-1 * fuel_cost, p.s.financial.boiler_fuel_cost_escalation_rate_fraction)
+        var_om = tech.om_cost_per_kwh * d["Boiler"]["annual_thermal_production_mmbtu"] * KWH_PER_MMBTU
+        fixed_om = tech.om_cost_per_kw * d["Boiler"]["size_mmbtu_per_hour"] * KWH_PER_MMBTU
+        annual_om = -1 * (var_om + fixed_om)
+        m.om_series += escalate_om(annual_om)
+        
+        # Depreciation
+        if tech.macrs_option_years in [5 ,7]
+            depreciation_schedule = get_depreciation_schedule(p, tech)
+            m.total_depreciation += depreciation_schedule
+        end
+    end
+
+    # calculate Absorption Chiller o+m costs and depreciation (no incentives currently)
+    if "AbsorptionChiller" in keys(d) && d["AbsorptionChiller"]["size_ton"] > 0
+        # Some thermal techs (e.g. Boiler) only have struct fields for O&M "per_kw" (converted from e.g. per_mmbtu_per_hour or per_ton)
+        #   but Absorption Chiller also has the input-style "per_ton" O&M, so no need to convert like for Boiler
+        fixed_om = tech.om_cost_per_ton * d["Absorption"]["size_ton"]
+        
+        annual_om = -1 * (fixed_om)
+        m.om_series += escalate_om(annual_om)
+        
+        # Depreciation
+        if tech.macrs_option_years in [5 ,7]
+            depreciation_schedule = get_depreciation_schedule(p, tech)
+            m.total_depreciation += depreciation_schedule
+        end
+    end    
 
     # calculate GHP incentives, and depreciation
     if "GHP" in keys(d) && d["GHP"]["ghp_option_chosen"] > 0
@@ -284,10 +344,20 @@ function update_metrics(m::Metrics, p::REoptInputs, tech::AbstractTech, tech_nam
     total_kw = results[tech_name]["size_kw"]
     existing_kw = :existing_kw in fieldnames(typeof(tech)) ? tech.existing_kw : 0
     new_kw = total_kw - existing_kw
-    capital_cost = new_kw * tech.installed_cost_per_kw
+    if tech_name == "CHP"
+        capital_cost = get_chp_initial_capex(p, results["CHP"]["size_kw"])
+    else
+        capital_cost = new_kw * tech.installed_cost_per_kw
+    end
 
-    # owner is responsible for both new and existing PV maintenance in optimal case
-    if third_party
+    # owner is responsible for both new and existing PV (or Generator) maintenance in optimal case
+    # CHP doesn't have existing CHP, and it has different O&M cost parameters
+    if tech_name == "CHP"
+        hours_operating = sum(results["CHP"]["electric_production_series_kw"] .> 0.0) / (8760 * p.s.settings.time_steps_per_hour)
+        annual_om = -1 * (results["CHP"]["annual_electric_production_kwh"] * tech.om_cost_per_kwh + 
+                            new_kw * tech.om_cost_per_kw + 
+                            new_kw * tech.om_cost_per_hr_per_kw_rated * hours_operating)
+    elseif third_party
         annual_om = -1 * new_kw * tech.om_cost_per_kw
     else
         annual_om = -1 * total_kw * tech.om_cost_per_kw
@@ -296,6 +366,12 @@ function update_metrics(m::Metrics, p::REoptInputs, tech::AbstractTech, tech_nam
     escalate_om(val) = [val * (1 + p.s.financial.om_cost_escalation_rate_fraction)^yr for yr in 1:years]
     m.om_series += escalate_om(annual_om)
     m.om_series_bau += escalate_om(-1 * existing_kw * tech.om_cost_per_kw)
+
+    if tech_name == "CHP"
+        escalate_fuel(val, esc_rate) = [val * (1 + esc_rate)^yr for yr in 1:years]
+        fuel_cost = results["CHP"]["year_one_fuel_cost_before_tax"]
+        m.om_series += escalate_fuel(-1 * fuel_cost, p.s.financial.chp_fuel_cost_escalation_rate_fraction)
+    end
 
     # incentive calculations, in the spreadsheet utility incentives are applied first
     utility_ibi = minimum([capital_cost * tech.utility_ibi_fraction, tech.utility_ibi_max])
@@ -311,7 +387,11 @@ function update_metrics(m::Metrics, p::REoptInputs, tech::AbstractTech, tech_nam
     pbi_series = Float64[]
     pbi_series_bau = Float64[]
     existing_energy_bau = third_party ? get(results[tech_name], "year_one_energy_produced_kwh_bau", 0) : 0
-    year_one_energy = "year_one_energy_produced_kwh" in keys(results[tech_name]) ? results[tech_name]["year_one_energy_produced_kwh"] : results[tech_name]["annual_energy_produced_kwh"]
+    if tech_name == "CHP"
+        year_one_energy = results[tech_name]["annual_electric_production_kwh"]
+    else
+        year_one_energy = "year_one_energy_produced_kwh" in keys(results[tech_name]) ? results[tech_name]["year_one_energy_produced_kwh"] : results[tech_name]["annual_energy_produced_kwh"]
+    end
     for yr in range(0, stop=years-1)
         if yr < tech.production_incentive_years
             degradation_fraction = :degradation_fraction in fieldnames(typeof(tech)) ? (1 - tech.degradation_fraction)^yr : 1.0
@@ -334,31 +414,13 @@ function update_metrics(m::Metrics, p::REoptInputs, tech::AbstractTech, tech_nam
     m.total_pbi_bau += pbi_series_bau
 
     # Federal ITC 
-    # NOTE: bug in v1 has the ITC within the `if tech.macrs_option_years in [5 ,7]` block.
-    # NOTE: bug in v1 reduces the federal_itc_basis with the federal_cbi, which is incorrect
     federal_itc_basis = capital_cost - state_ibi - utility_ibi - state_cbi - utility_cbi
     federal_itc_amount = tech.federal_itc_fraction * federal_itc_basis
     m.federal_itc += federal_itc_amount
 
     # Depreciation
     if tech.macrs_option_years in [5 ,7]
-        schedule = []
-        if tech.macrs_option_years == 5
-            schedule = p.s.financial.macrs_five_year
-        elseif tech.macrs_option_years == 7
-            schedule = p.s.financial.macrs_seven_year
-        end
-
-        macrs_bonus_basis = federal_itc_basis - federal_itc_basis * tech.federal_itc_fraction * tech.macrs_itc_reduction
-        macrs_basis = macrs_bonus_basis * (1 - tech.macrs_bonus_fraction)
-
-        depreciation_schedule = zeros(years)
-        for (i, r) in enumerate(schedule)
-            if i < length(depreciation_schedule)
-                depreciation_schedule[i] = macrs_basis * r
-            end
-        end
-        depreciation_schedule[1] += (tech.macrs_bonus_fraction * macrs_bonus_basis)
+        depreciation_schedule = get_depreciation_schedule(p, tech, federal_itc_basis)
         m.total_depreciation += depreciation_schedule
     end
     nothing
@@ -407,31 +469,13 @@ function update_ghp_metrics(m::REopt.Metrics, p::REoptInputs, tech::REopt.Abstra
     m.total_pbi_bau += pbi_series_bau
 
     # Federal ITC 
-    # NOTE: bug in v1 has the ITC within the `if tech.macrs_option_years in [5 ,7]` block.
-    # NOTE: bug in v1 reduces the federal_itc_basis with the federal_cbi, which is incorrect
     federal_itc_basis = capital_cost - state_ibi - utility_ibi - state_cbi - utility_cbi
     federal_itc_amount = tech.federal_itc_fraction * federal_itc_basis
     m.federal_itc += federal_itc_amount
 
     # Depreciation
     if tech.macrs_option_years in [5 ,7]
-        schedule = []
-        if tech.macrs_option_years == 5
-            schedule = p.s.financial.macrs_five_year
-        elseif tech.macrs_option_years == 7
-            schedule = p.s.financial.macrs_seven_year
-        end
-
-        macrs_bonus_basis = federal_itc_basis - federal_itc_basis * tech.federal_itc_fraction * tech.macrs_itc_reduction
-        macrs_basis = macrs_bonus_basis * (1 - tech.macrs_bonus_fraction)
-
-        depreciation_schedule = zeros(years)
-        for (i, r) in enumerate(schedule)
-            if i < length(depreciation_schedule)
-                depreciation_schedule[i] = macrs_basis * r
-            end
-        end
-        depreciation_schedule[1] += (tech.macrs_bonus_fraction * macrs_bonus_basis)
+        depreciation_schedule = get_depreciation_schedule(p, tech, federal_itc_basis)
         m.total_depreciation += depreciation_schedule
     end
     nothing
@@ -452,6 +496,6 @@ function irr(cashflows::AbstractArray{<:Real, 1})
     try
         rate = fzero(f, [0.0, 0.99])
     finally
-        return round(rate, digits=2)
+        return round(rate, digits=3)
     end
 end

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -107,16 +107,22 @@ function proforma_results(p::REoptInputs, d::Dict)
             year_one_fuel_cost_bau = d["Generator"]["year_one_fuel_cost_before_tax_bau"]
         end
         if !third_party
-            annual_om = -1 * (fixed_and_var_om + d["Generator"]["year_one_fuel_cost_before_tax"])
-
-            annual_om_bau = -1 * (fixed_and_var_om_bau + year_one_fuel_cost_bau)
-        else
+            annual_fuel = -1 * d["Generator"]["year_one_fuel_cost_before_tax"]
             annual_om = -1 * fixed_and_var_om
 
+            annual_fuel_bau = -1 * year_one_fuel_cost_bau
+            annual_om_bau = -1 * fixed_and_var_om_bau
+        else
+            annual_fuel = 0.0
+            annual_om = -1 * fixed_and_var_om
+
+            annual_fuel_bau = 0.0
             annual_om_bau = -1 * fixed_and_var_om_bau
         end
 
+        m.om_series += escalate_fuel(annual_fuel, p.s.financial.generator_fuel_cost_escalation_rate_fraction)
         m.om_series += escalate_om(annual_om)
+        m.om_series_bau += escalate_fuel(annual_fuel_bau, p.s.financial.generator_fuel_cost_escalation_rate_fraction)
         m.om_series_bau += escalate_om(annual_om_bau)
     end
 

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -86,23 +86,8 @@ function proforma_results(p::REoptInputs, d::Dict)
         m.federal_itc += federal_itc_amount
 
         # Depreciation
-        if storage.macrs_option_years in [5, 7]
-            schedule = []
-            if storage.macrs_option_years == 5
-                schedule = p.s.financial.macrs_five_year
-            elseif storage.macrs_option_years == 7
-                schedule = p.s.financial.macrs_seven_year
-            end
-            macrs_bonus_basis = federal_itc_basis * (1 - storage.total_itc_fraction * storage.macrs_itc_reduction)
-            macrs_basis = macrs_bonus_basis * (1 - storage.macrs_bonus_fraction)
-
-            depreciation_schedule = zeros(years)
-            for (i, r) in enumerate(schedule)
-                if i < length(depreciation_schedule)
-                    depreciation_schedule[i] = macrs_basis * r
-                end
-            end
-            depreciation_schedule[1] += storage.macrs_bonus_fraction * macrs_bonus_basis
+        if storage.macrs_option_years in [5 ,7]
+            depreciation_schedule = get_depreciation_schedule(p, storage)
             m.total_depreciation += depreciation_schedule
         end
     end
@@ -157,8 +142,6 @@ function proforma_results(p::REoptInputs, d::Dict)
         fixed_om_bau = 0.0
         annual_om_bau = -1 * (var_om_bau + fixed_om_bau)
         m.om_series_bau += escalate_om(annual_om_bau)
-
-    
     end    
 
     # calculate (new) Boiler o+m costs and depreciation (no incentives currently)

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -107,19 +107,12 @@ function proforma_results(p::REoptInputs, d::Dict)
                                    d["Generator"]["year_one_variable_om_cost_before_tax_bau"]
             year_one_fuel_cost_bau = d["Generator"]["year_one_fuel_cost_before_tax_bau"]
         end
-        if !third_party
-            annual_fuel = -1 * d["Generator"]["year_one_fuel_cost_before_tax"]
-            annual_om = -1 * fixed_and_var_om
 
-            annual_fuel_bau = -1 * year_one_fuel_cost_bau
-            annual_om_bau = -1 * fixed_and_var_om_bau
-        else
-            annual_fuel = 0.0
-            annual_om = -1 * fixed_and_var_om
+        annual_fuel = -1 * d["Generator"]["year_one_fuel_cost_before_tax"]
+        annual_om = -1 * fixed_and_var_om
 
-            annual_fuel_bau = 0.0
-            annual_om_bau = -1 * fixed_and_var_om_bau
-        end
+        annual_fuel_bau = -1 * year_one_fuel_cost_bau
+        annual_om_bau = -1 * fixed_and_var_om_bau
 
         m.om_series += escalate_om(annual_om)
         m.fuel_cost_series += escalate_fuel(annual_fuel, p.s.financial.generator_fuel_cost_escalation_rate_fraction)

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -24,7 +24,7 @@ Recreates the ProForma spreadsheet calculations to get the simple payback period
 party case), and payment to third party (3rd party case).
 
 return Dict(
-    "simple_payback_years" => 0.0,
+    "simple_payback_years" => 0.0, # The year in which cumulative net free cashflows become positive. For a third party analysis, the SPP is for the developer.
     "internal_rate_of_return" => 0.0,
     "net_present_cost" => 0.0,
     "annualized_payment_to_third_party" => 0.0,
@@ -32,7 +32,8 @@ return Dict(
     "offtaker_annual_free_cashflows_bau" => Float64[],
     "offtaker_discounted_annual_free_cashflows" => Float64[],
     "offtaker_discounted_annual_free_cashflows_bau" => Float64[],
-    "developer_annual_free_cashflows" => Float64[]
+    "developer_annual_free_cashflows" => Float64[],
+    "net_capital_costs_without_macrs" => 0.0 # Initial capital costs after ibi, cbi, and ITC incentives
 )
 """
 function proforma_results(p::REoptInputs, d::Dict)
@@ -97,9 +98,8 @@ function proforma_results(p::REoptInputs, d::Dict)
 
     # calculate Generator o+m costs, incentives, and depreciation
     if "Generator" in keys(d) && d["Generator"]["size_kw"] > 0
-        # In the two party case the developer does not include the fuel cost in their costs
-        # It is assumed that the offtaker will pay for this at a rate that is not marked up
-        # to cover developer profits
+        # In the two party case the developer does not include the fuel cost or O&M costs for existing assets in their costs
+        # It is assumed that the offtaker will pay for this at a rate that is not marked up to cover developer profits
         fixed_and_var_om = d["Generator"]["year_one_fixed_om_cost_before_tax"] + d["Generator"]["year_one_variable_om_cost_before_tax"]
         fixed_and_var_om_bau = 0.0
         year_one_fuel_cost_bau = 0.0

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -106,7 +106,9 @@ function proforma_results(p::REoptInputs, d::Dict)
         if p.s.generator.existing_kw > 0
             fixed_and_var_om_bau = d["Generator"]["year_one_fixed_om_cost_before_tax_bau"] + 
                                    d["Generator"]["year_one_variable_om_cost_before_tax_bau"]
-            fixed_and_var_om -= fixed_and_var_om_bau
+            if third_party
+                fixed_and_var_om -= fixed_and_var_om_bau
+            end
             year_one_fuel_cost_bau = d["Generator"]["year_one_fuel_cost_before_tax_bau"]
         end
 

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -352,7 +352,7 @@ function update_metrics(m::Metrics, p::REoptInputs, tech::AbstractTech, tech_nam
         capital_cost = new_kw * tech.installed_cost_per_kw
     end
 
-    # owner is responsible for both new and existing PV (or Generator) maintenance in optimal case
+    # owner is responsible for only new technologies operating and maintenance cost in optimal case
     # CHP doesn't have existing CHP, and it has different O&M cost parameters
     if tech_name == "CHP"
         hours_operating = sum(results["CHP"]["electric_production_series_kw"] .> 0.0) / (8760 * p.s.settings.time_steps_per_hour)

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -252,15 +252,6 @@ function proforma_results(p::REoptInputs, d::Dict)
 
         annual_income_from_host_series = repeat([-1 * r["annualized_payment_to_third_party"]], years)
 
-        net_energy_costs = -electricity_bill_series_bau - export_credit_series_bau - m.fuel_cost_series_bau + electricity_bill_series + 
-                           export_credit_series + annual_income_from_host_series + m.fuel_cost_series
-
-        if p.s.financial.owner_tax_rate_fraction > 0
-            deductable_net_energy_costs = copy(net_energy_costs)
-        else
-            deductable_net_energy_costs = zeros(years)
-        end
-
         r["offtaker_annual_free_cashflows"] = append!([0.0], 
             electricity_bill_series + export_credit_series + m.fuel_cost_series + annual_income_from_host_series
         )

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -162,8 +162,8 @@ function proforma_results(p::REoptInputs, d::Dict)
 
     # calculate Steam Turbine o+m costs and depreciation (no incentives currently)
     if "SteamTurbine" in keys(d) && get(d["SteamTurbine"], "size_kw", 0) > 0
-        fixed_om = tech.om_cost_per_kw * d["SteamTurbine"]["size_kw"]
-        var_om = tech.om_cost_per_kwh * d["SteamTurbine"]["annual_electric_production_kwh"]
+        fixed_om = p.s.steam_turbine.om_cost_per_kw * d["SteamTurbine"]["size_kw"]
+        var_om = p.s.steam_turbine.om_cost_per_kwh * d["SteamTurbine"]["annual_electric_production_kwh"]
         annual_om = -1 * (fixed_om + var_om)
         m.om_series += escalate_om(annual_om)
         
@@ -178,7 +178,7 @@ function proforma_results(p::REoptInputs, d::Dict)
     if "AbsorptionChiller" in keys(d) && d["AbsorptionChiller"]["size_ton"] > 0
         # Some thermal techs (e.g. Boiler) only have struct fields for O&M "per_kw" (converted from e.g. per_mmbtu_per_hour or per_ton)
         #   but Absorption Chiller also has the input-style "per_ton" O&M, so no need to convert like for Boiler
-        fixed_om = tech.om_cost_per_ton * d["Absorption"]["size_ton"]
+        fixed_om = p.s.absorption_chiller.om_cost_per_ton * d["AbsorptionChiller"]["size_ton"]
         
         annual_om = -1 * (fixed_om)
         m.om_series += escalate_om(annual_om)

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -97,7 +97,6 @@ function proforma_results(p::REoptInputs, d::Dict)
         # In the two party case the developer does not include the fuel cost in their costs
         # It is assumed that the offtaker will pay for this at a rate that is not marked up
         # to cover developer profits
-        # TODO escalate fuel cost with p.s.financial.generator_fuel_cost_escalation_rate_fraction
         fixed_and_var_om = d["Generator"]["year_one_fixed_om_cost_before_tax"] + d["Generator"]["year_one_variable_om_cost_before_tax"]
         fixed_and_var_om_bau = 0.0
         year_one_fuel_cost_bau = 0.0
@@ -131,7 +130,7 @@ function proforma_results(p::REoptInputs, d::Dict)
         update_metrics(m, p, p.s.chp, "CHP", d, third_party)
     end
 
-    # calculate (new) Boiler o+m costs (just fuel, no non-fuel operating costs currently)
+    # calculate ExistingBoiler o+m costs (just fuel, no non-fuel operating costs currently)
     # the optional installed_cost inputs assume net present cost so no option for MACRS or incentives
     if "ExistingBoiler" in keys(d) && d["ExistingBoiler"]["size_mmbtu_per_hour"] > 0
         fuel_cost = d["ExistingBoiler"]["year_one_fuel_cost_before_tax"]
@@ -150,7 +149,7 @@ function proforma_results(p::REoptInputs, d::Dict)
         m.om_series_bau += escalate_om(annual_om_bau)
     end    
 
-    # calculate (new) Boiler o+m costs and depreciation (no incentives currently)
+    # calculate (new) Boiler o+m costs and depreciation (no incentives currently, other than MACRS)
     if "Boiler" in keys(d) && d["Boiler"]["size_mmbtu_per_hour"] > 0
         fuel_cost = d["Boiler"]["year_one_fuel_cost_before_tax"]
         m.om_series += escalate_fuel(-1 * fuel_cost, p.s.financial.boiler_fuel_cost_escalation_rate_fraction)
@@ -166,7 +165,7 @@ function proforma_results(p::REoptInputs, d::Dict)
         end
     end
 
-    # calculate Steam Turbine o+m costs and depreciation (no incentives currently)
+    # calculate Steam Turbine o+m costs and depreciation (no incentives currently, other than MACRS)
     if "SteamTurbine" in keys(d) && get(d["SteamTurbine"], "size_kw", 0) > 0
         fixed_om = p.s.steam_turbine.om_cost_per_kw * d["SteamTurbine"]["size_kw"]
         var_om = p.s.steam_turbine.om_cost_per_kwh * d["SteamTurbine"]["annual_electric_production_kwh"]
@@ -180,7 +179,7 @@ function proforma_results(p::REoptInputs, d::Dict)
         end
     end     
 
-    # calculate Absorption Chiller o+m costs and depreciation (no incentives currently)
+    # calculate Absorption Chiller o+m costs and depreciation (no incentives currently, other than MACRS)
     if "AbsorptionChiller" in keys(d) && d["AbsorptionChiller"]["size_ton"] > 0
         # Some thermal techs (e.g. Boiler) only have struct fields for O&M "per_kw" (converted from e.g. per_mmbtu_per_hour or per_ton)
         #   but Absorption Chiller also has the input-style "per_ton" O&M, so no need to convert like for Boiler

--- a/src/results/proforma.jl
+++ b/src/results/proforma.jl
@@ -45,7 +45,8 @@ function proforma_results(p::REoptInputs, d::Dict)
         "offtaker_annual_free_cashflows_bau" => Float64[],
         "offtaker_discounted_annual_free_cashflows" => Float64[],
         "offtaker_discounted_annual_free_cashflows_bau" => Float64[],
-        "developer_annual_free_cashflows" => Float64[]
+        "developer_annual_free_cashflows" => Float64[],
+        "net_capital_costs_without_macrs" => 0.0
     )
     years = p.s.financial.analysis_years
     escalate_elec(val) = [-1 * val * (1 + p.s.financial.elec_cost_escalation_rate_fraction)^yr for yr in 1:years]
@@ -221,6 +222,7 @@ function proforma_results(p::REoptInputs, d::Dict)
     total_cash_incentives = m.total_pbi * (1 - tax_rate_fraction)
     free_cashflow_without_year_zero = m.total_depreciation * tax_rate_fraction + total_cash_incentives + operating_expenses_after_tax
     free_cashflow_without_year_zero[1] += m.federal_itc
+    r["net_capital_costs_without_macrs"] = d["Financial"]["initial_capital_costs"] - m.total_ibi_and_cbi - m.federal_itc
     free_cashflow = append!([(-1 * d["Financial"]["initial_capital_costs"]) + m.total_ibi_and_cbi], free_cashflow_without_year_zero)
 
     # At this point the logic branches based on third-party ownership or not - see comments    

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ else  # run HiGHS tests
             latitude, longitude = 3.8603988398663125, 11.528880303663136
             radius = 0
             dataset, distance, datasource = REopt.call_solar_dataset_api(latitude, longitude, radius)
-            @test dataset ≈ "intl"
+            @test dataset ≈ "nsrdb"
 
             # 4. Fairbanks, AK 
             site = "Fairbanks"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -991,7 +991,7 @@ else  # run HiGHS tests
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
             set_optimizer_attribute(m, "mip_rel_gap", 0.01)
             r = run_reopt(m, d)
-            @test occursin("Unable to use IndicatorToMILPBridge", string(r["Messages"]["errors"]))
+            @test occursin("are not supported by the solver", string(r["Messages"]["errors"])) || occursin("Unable to use IndicatorToMILPBridge", string(r["Messages"]["errors"]))
             # #optimal SOH at end of horizon is 80\% to prevent any replacement
             # @test sum(value.(m[:bmth_BkWh])) ≈ 0 atol=0.1
             # # @test r["ElectricStorage"]["maintenance_cost"] ≈ 2972.66 atol=0.01 
@@ -1005,7 +1005,7 @@ else  # run HiGHS tests
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
             set_optimizer_attribute(m, "mip_rel_gap", 0.01)
             r = run_reopt(m, d)
-            @test occursin("Unable to use IndicatorToMILPBridge", string(r["Messages"]["errors"]))
+            @test occursin("are not supported by the solver", string(r["Messages"]["errors"])) || occursin("Unable to use IndicatorToMILPBridge", string(r["Messages"]["errors"]))
             # @test round(sum(r["ElectricStorage"]["soc_series_fraction"]), digits=2) / 8760 >= 0.7199
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1947,8 +1947,8 @@ else  # run HiGHS tests
             @test abs(results["Financial"]["lifecycle_capital_costs"] - 0.7*results["Financial"]["initial_capital_costs"]) < 150.0
 
             @test abs(results["Financial"]["npv"] - 840621) < 1.0
-            @test results["Financial"]["simple_payback_years"] - 5.09 < 0.1
-            @test results["Financial"]["internal_rate_of_return"] - 0.18 < 0.01
+            @test abs(results["Financial"]["simple_payback_years"] - 3.59) < 0.1
+            @test abs(results["Financial"]["internal_rate_of_return"] - 0.258) < 0.01
 
             @test haskey(results["ExistingBoiler"], "year_one_fuel_cost_before_tax_bau")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -991,7 +991,7 @@ else  # run HiGHS tests
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
             set_optimizer_attribute(m, "mip_rel_gap", 0.01)
             r = run_reopt(m, d)
-            @test occursin("not supported by the solver", string(r["Messages"]["errors"]))
+            @test occursin("Unable to use IndicatorToMILPBridge", string(r["Messages"]["errors"]))
             # #optimal SOH at end of horizon is 80\% to prevent any replacement
             # @test sum(value.(m[:bmth_BkWh])) ≈ 0 atol=0.1
             # # @test r["ElectricStorage"]["maintenance_cost"] ≈ 2972.66 atol=0.01 
@@ -1005,7 +1005,7 @@ else  # run HiGHS tests
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
             set_optimizer_attribute(m, "mip_rel_gap", 0.01)
             r = run_reopt(m, d)
-            @test occursin("not supported by the solver", string(r["Messages"]["errors"]))
+            @test occursin("Unable to use IndicatorToMILPBridge", string(r["Messages"]["errors"]))
             # @test round(sum(r["ElectricStorage"]["soc_series_fraction"]), digits=2) / 8760 >= 0.7199
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -660,8 +660,8 @@ else  # run HiGHS tests
                 m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.01, "presolve" => "on"))
                 results = run_reopt(m, inputs)
             
-                @test round(results["CHP"]["size_kw"], digits=0) ≈ 400.0 atol=50.0
-                @test round(results["Financial"]["lcc"], digits=0) ≈ 1.3476e7 rtol=1.0e-2
+                @test round(results["CHP"]["size_kw"], digits=0) ≈ 263.0 atol=50.0
+                @test round(results["Financial"]["lcc"], digits=0) ≈ 1.11e7 rtol=0.05
             end
         
             @testset "CHP Cost Curve and Min Allowable Size" begin

--- a/test/scenarios/chp_payback.json
+++ b/test/scenarios/chp_payback.json
@@ -1,0 +1,86 @@
+{
+    "Financial": {
+        "offtaker_tax_rate_fraction": 0.26,
+        "elec_cost_escalation_rate_fraction": 0.017,
+        "chp_fuel_cost_escalation_rate_fraction": 0.015,
+        "existing_boiler_fuel_cost_escalation_rate_fraction": 0.015,
+        "om_cost_escalation_rate_fraction": 0.025
+    },
+    "Settings": {
+        "solver_name": "HiGHS",
+        "off_grid_flag": false,
+        "include_climate_in_objective": false,
+        "include_health_in_objective": false
+    },
+    "Site": {
+        "latitude": 41.8809434,
+        "longitude": -72.2600655,
+        "include_exported_renewable_electricity_in_total": true,
+        "include_exported_elec_emissions_in_total": true,
+        "land_acres": 1000000.0,
+        "roof_squarefeet": 0
+    },
+    "ElectricLoad": {
+        "monthly_totals_kwh": [
+            921984.0,
+            884352.0,
+            912576.0,
+            921984.0,
+            950208.0,
+            903168.0,
+            1025472.0,
+            978432.0,
+            1072512.0,
+            1044288.0,
+            987840.0,
+            950208.0
+        ],
+        "critical_load_fraction": 0.8,
+        "doe_reference_name": "FlatLoad"
+    },
+    "ElectricTariff": {
+        "blended_annual_demand_rate": 21.487,
+        "blended_annual_energy_rate": 0.0788
+    },
+    "ElectricUtility": {
+        "net_metering_limit_kw": 0.0,
+        "avert_emissions_region": "New England",
+        "cambium_location_type": "GEA Regions",
+        "cambium_levelization_years": 1,
+        "cambium_metric_col": "lrmer_co2e",
+        "cambium_scenario": "Mid-case",
+        "cambium_grid_level": "enduse"
+    },
+    "Generator": {
+        "max_kw": 0,
+        "existing_kw": 0
+    },
+    "CHP": {
+        "can_net_meter": false,
+        "prime_mover": "recip_engine",
+        "size_class": 5,
+        "min_kw": 1104.0,
+        "min_allowable_kw": 1104.0,
+        "max_kw": 1104.0,
+        "fuel_type": "natural_gas",
+        "can_wholesale": false,
+        "fuel_cost_per_mmbtu": 10.55,
+        "federal_itc_fraction": 0.3,
+        "macrs_option_years": 5,
+        "macrs_bonus_fraction": 0.8,
+        "macrs_itc_reduction": 0.5        
+    },
+    "DomesticHotWaterLoad": {
+        "annual_mmbtu": 6795.0,
+        "doe_reference_name": "FlatLoad"
+    },
+    "SpaceHeatingLoad": {
+        "annual_mmbtu": 36205.0,
+        "doe_reference_name": "FlatLoad"
+    },
+    "ExistingBoiler": {
+        "fuel_type": "natural_gas",
+        "production_type": "hot_water",
+        "fuel_cost_per_mmbtu": 10.55
+    }
+}

--- a/test/scenarios/chp_sizing.json
+++ b/test/scenarios/chp_sizing.json
@@ -17,7 +17,8 @@
         "doe_reference_name": "Hospital"
     },
     "ElectricTariff": {
-        "urdb_label": "5e1676e95457a3f87673e3b0"
+        "blended_annual_energy_rate": 0.12,
+        "blended_annual_demand_rate": 10.0
     },
     "SpaceHeatingLoad": {
         "doe_reference_name": "Hospital"
@@ -40,11 +41,11 @@
         "om_cost_per_kw": 149.8,
         "om_cost_per_kwh": 0.0,
         "om_cost_per_hr_per_kw_rated": 0.0,
-        "electric_efficiency_full_load": 0.3573,
-        "electric_efficiency_half_load": 0.3216,
+        "electric_efficiency_full_load": 0.34,
+        "electric_efficiency_half_load": 0.34,
         "min_turn_down_fraction": 0.5,
-        "thermal_efficiency_full_load": 0.4418,
-        "thermal_efficiency_half_load": 0.4664,
+        "thermal_efficiency_full_load": 0.45,
+        "thermal_efficiency_half_load": 0.45,
         "macrs_option_years": 0,
         "macrs_bonus_fraction": 0.0,
         "macrs_itc_reduction": 0.0,


### PR DESCRIPTION
- Fixes proforma calcs including "simple" payback and IRR for thermal techs/scenarios. 
  - The operating costs of fuel and O&M were missing for all thermal techs such as ExistingBoiler, CHP, and others; this adds those sections of code to properly calculate the operating costs.
- Adds a test to validate the simple payback calculation with CHP (and ExistingBoiler) and checks the REopt result value against a spreadsheet proforma calculation (see Bill's spreadsheet)
- Adds a couple of missing techs for the initial capital cost calculation in financial.jl
- Fixes a few bugs here and there, including the setup_boiler_inputs in reopt_inputs.jl
- Improves DRY coding by replacing multiple instances of the same chunks of code for MACRS deprecation and CHP capital cost into functions that are now in financial.jl
- Simplifies the CHP sizing test to avoid a ~30 minute solve time, by avoiding the fuel burn y-intercept binaries which come with differences between full-load and part-load efficiency
- Added two new fields to the Metrics struct to append to for any fuel-burning technologies (just Generator, ExistingBoiler, Boiler, and CHP currently): fuel_cost_series and fuel_cost_series_bau which are now only added to the offtaker cashflows and not the owner/developer cashflows for third party.