### PR TITLE
Don't export if system sized above NEM limit (and no wholesale)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Classify the change according to the following categories:
     ### Removed
 
 
+## nem-export
+### Fixed
+- Constrained export to grid in the NEM bin (`dvProductionToGrid"*_n)][t, :NEM, ts`) to be 0 when system is sized over NEM limit (i.e., when binNEM =0)
+
 ## Develop
 ### Added
 - Battery residual value if choosing replacement strategy for degradation

--- a/src/constraints/electric_utility_constraints.jl
+++ b/src/constraints/electric_utility_constraints.jl
@@ -105,7 +105,6 @@ function add_export_constraints(m, p; _n="")
                 @constraint(m,[ts in p.time_steps_with_grid, t in p.techs_by_exportbin[:NEM]], 
                     m[Symbol("dvProductionToGrid"*_n)][t, :NEM, ts] <= binNEM * sum(p.s.electric_load.loads_kw)
                 )
-                p.s.electric_load.loads_kw
             end
 
             EXC_benefit = 0

--- a/src/constraints/electric_utility_constraints.jl
+++ b/src/constraints/electric_utility_constraints.jl
@@ -55,7 +55,6 @@ function add_export_constraints(m, p; _n="")
             max_bene = sum([ld*rate for (ld,rate) in zip(p.s.electric_load.loads_kw, p.s.electric_tariff.export_rates[:NEM])])*p.pwf_e*p.hours_per_time_step*10
             NEM_benefit = @variable(m, lower_bound = max_bene)
 
-            
             # If choosing to take advantage of NEM, must have total capacity less than net_metering_limit_kw
             if solver_is_compatible_with_indicator_constraints(p.s.settings.solver_name)
                 @constraint(m,
@@ -92,6 +91,10 @@ function add_export_constraints(m, p; _n="")
                     }
                 )
                 @constraint(m, !binNEM => {NEM_benefit >= 0})
+                @constraint(m,[ts in p.time_steps_with_grid, t in p.techs_by_exportbin[:NEM]], 
+                    !binNEM => { m[Symbol("dvProductionToGrid"*_n)][t, :NEM, ts] == 0
+                        }
+                )
             else
                 @constraint(m,
                     NEM_benefit >= p.pwf_e * p.hours_per_time_step *
@@ -99,6 +102,10 @@ function add_export_constraints(m, p; _n="")
                             for t in p.techs_by_exportbin[:NEM]) for ts in p.time_steps)
                 )
                 @constraint(m, NEM_benefit >= max_bene * binNEM)
+                @constraint(m,[ts in p.time_steps_with_grid, t in p.techs_by_exportbin[:NEM]], 
+                    m[Symbol("dvProductionToGrid"*_n)][t, :NEM, ts] <= binNEM * sum(p.s.electric_load.loads_kw)
+                )
+                p.s.electric_load.loads_kw
             end
 
             EXC_benefit = 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -652,7 +652,15 @@ else  # run HiGHS tests
                 m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
                 results = run_reopt(m, d)
                 @test results["PV"]["size_kw"] ≈ 7440.0 atol=1e-3  #max benefit provides the upper bound
-        
+
+                #case 3: net metering limit is exceeded, no WHL, and min RE % 
+                d["ElectricTariff"]["wholesale_rate"] = 0
+                d["PV"]["min_kw"] = 50
+                d["Site"]["renewable_electricity_min_fraction"] = 0.35
+                m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
+                results = run_reopt(m, d)
+                @test sum(results["PV"]["electric_to_grid_series_kw"]) ≈ 0.0 atol=1e-3
+                @test results["ElectricTariff"]["lifecycle_export_benefit_after_tax"] ≈ 0.0 atol=1e-3        
             end
         end
 


### PR DESCRIPTION
### Fixed
- Constrained export to grid in the NEM bin (`dvProductionToGrid"*_n)][t, :NEM, ts`) to be 0 when system is sized over NEM limit (i.e., when binNEM =0)


This addresses an observed issue in which REopt was arbitrarily choosing to export power into the NEM bin without receiving any NEM compensation, when a system was sized above the net_metering_limit_kw. 