### PR TITLE
Hot Fix: Remove error throw with inconsistent load year between elect…

### DIFF
--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -826,6 +826,6 @@ end
 
 function validate_load_year_consistency(electric_load_year, year, load_type)
     if electric_load_year != year
-        throw(@error("Inconsistent load years: ElectricLoad year ($electric_load_year) does not match the provided year ($year) for $load_type."))
+        @warn "Inconsistent load years: ElectricLoad year ($electric_load_year) does not match the provided year ($year) for $load_type."
     end
 end


### PR DESCRIPTION
Hot Fix: Remove error throw with inconsistent load year between electric and heating

This is causing issues with common web-tool usage.

A longer term fix will be pushed soon.