### PR TITLE
Fix leap year (e.g. 2024!) handling of URDB demand and energy charges

### DIFF
--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -408,11 +408,11 @@ return Array{Int, 1} for time_steps in ratchet (aka period)
 function get_tou_demand_steps(d::Dict; year::Int, month::Int, period::Int, time_steps_per_hour=1)
     if month > 1
         plus_days = 0
+        if month == 12 && isleapyear(year)
+            plus_days -= 1
+        end
         for m in range(1, stop=month-1)
             plus_days += daysinmonth(Date(string(year) * "-" * string(m)))
-            if m == 2 && isleapyear(year)
-                plus_days -= 1
-            end
         end
         start_hour = 1 + plus_days * 24
         start_step = 1 + plus_days * 24 * time_steps_per_hour

--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -224,7 +224,7 @@ function parse_urdb_energy_costs(d::Dict, year::Int; time_steps_per_hour=1, bigM
             end
 
             n_days = daysinmonth(Date(string(year) * "-" * string(month)))
-            if month == 2 && isleapyear(year)
+            if month == 12 && isleapyear(year)
                 n_days -= 1
             end
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -550,7 +550,7 @@ function get_monthly_time_steps(year::Int; time_steps_per_hour=1)
     for m in range(1, stop=12)
         n_days = daysinmonth(Date(string(year) * "-" * string(m)))
         stop = n_days * 24 * time_steps_per_hour + i - 1
-        if m == 2 && isleapyear(year)
+        if m == 12 && isleapyear(year)
             stop -= 24 * time_steps_per_hour  # TODO support extra day in leap years?
         end
         steps = [step for step in range(i, stop=stop)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1188,7 +1188,7 @@ else  # run HiGHS tests
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
             results = run_reopt(m, "./scenarios/outages_gen_pv_stor.json")
             @test results["Outages"]["expected_outage_cost"] ≈ 3.54476923e6 atol=10
-            @test results["Financial"]["lcc"] ≈ 8.6413594727e7 rtol=0.001
+            @test results["Financial"]["lcc"] ≈ 8.63559824639e7 rtol=0.001
 
             # Scenario with generator, PV, wind, electric storage
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
@@ -1197,7 +1197,7 @@ else  # run HiGHS tests
             @test value(m[:binMGTechUsed]["PV"]) ≈ 1
             @test value(m[:binMGTechUsed]["Wind"]) ≈ 1
             @test results["Outages"]["expected_outage_cost"] ≈ 1.296319791276051e6 atol=1.0
-            @test results["Financial"]["lcc"] ≈ 4.8046446434e6 rtol=0.001
+            @test results["Financial"]["lcc"] ≈ 4.833635288e6 rtol=0.001
             
         end
 


### PR DESCRIPTION
Currently, for a custom electric load profile (`ElectricLoad.loads_kw`) input for a leap `year` (e.g. 2024!), we instruct users to truncate the **last day of the year**, but within the code we actually take out the **leap day** for the URDB energy and demand charge schedule. This was causing the following issues for leap years:
1. The load (which includes the 2/29 day) would be shifted forward by one day after 2/28 relative to the energy charges, so weekday/weekend charges would be off periodically.
2. The facility/flat demand charge (`m[DemandFlatCharges]`) timesteps are shifted by a day for each month after February relative to the load - this only influences things if the billed demand is set on the last day of the month.
3. The TOU demand charges (`m[DemandTOUCharges]`) timesteps are shifted by a day after February which can affect the weekday/weekend aspect to the time periods in which the demand charges are set.

This PR fixes these issues by keeping the leap day in the rate tariff timesteps to align with the load, and instead removes the last day of the year to preserve the 8760 hours in the representative year.