### PR TITLE
Fix fuel cost for non-hourly timesteps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Classify the change according to the following categories:
     ### Removed
 
 
+# non-hourly-fuel-cost
+### Fixed
+- Fixed handling of non-hourly (e.g. 15-min interval) fuel cost
+
 ## v0.51.1
 ### Added
 - Added the following output fields: `year_one_fuel_cost_after_tax` for `ExistingBoiler`, `CHP`, `Generator`, and `Boiler`; `ElectricTariff`: `year_one_bill_after_tax` and `year_one_export_benefit_after_tax`, `Financial`: `capital_costs_after_non_discounted_incentives`, `year_one_total_operating_cost_savings_before_tax`, `year_one_total_operating_cost_savings_after_tax`, `year_one_total_operating_cost_before_tax`, `year_one_total_operating_cost_after_tax`, `year_one_fuel_cost_before_tax`, `year_one_fuel_cost_after_tax`, `year_one_chp_standby_cost_after_tax`, `year_one_chp_standby_cost_after_tax`, `GHP.avoided_capex_by_ghp_present_value`

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -291,7 +291,7 @@ end
 Convert a per hour value (eg. dollars/kWh) to time series that matches the settings.time_steps_per_hour
 """
 function per_hour_value_to_time_series(x::T, time_steps_per_hour::Int, name::String) where T <: Real
-    repeat([x / time_steps_per_hour], 8760 * time_steps_per_hour)
+    repeat([x], 8760 * time_steps_per_hour)
 end
 
 
@@ -309,7 +309,7 @@ function per_hour_value_to_time_series(x::AbstractVector{<:Real}, time_steps_per
     if length(x) == 12  # assume monthly values
         for mth in 1:12
             append!(vals, repeat(
-                [x[mth] / time_steps_per_hour], 
+                [x[mth]], 
                 time_steps_per_hour * 24 * daysinmonth(Date("2017-" * string(mth)))
                 )
             )


### PR DESCRIPTION
Do NOT divide fuel cost by time_steps_per_hour