### PR TITLE
Reduce memory growth on runtests.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.10']
         julia-arch: [x64]
-        os: [macos-latest-large]
+        os: [windows-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.10']
         julia-arch: [x64]
-        os: [windows-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.10']
         julia-arch: [x64]
-        os: [ubuntu-latest]
+        os: [macos-latest-large]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         julia-version: ['1.10']
         julia-arch: [x64]
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## test-runners
+### Added
+- Memory-clearing commands after each JuMP model instance in `runtests.jl` to avoid memory buildup which were slowing down Actions test job
+- Added back `ubuntu` OS as an additional runner OS for the tests Action job, now that memory buildup is reduced (removed a year ago due to memory crashing the runner)
+
 ## v0.52.0
 ### Added
 - Add **Financial** inputs `min_initial_capital_costs_before_incentives` and `max_initial_capital_costs_before_incentives` which, when provided, provide upper and lower bounds on initial capital costs for all technologies.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,9 @@ else  # run HiGHS tests
             with_logger(logger) do
                 model = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
                 results = run_reopt(model, "./scenarios/simultaneous_charge_discharge.json")
+                finalize(backend(model))
+                empty!(model)
+                GC.gc()
             end
             @test any(.&(
                     results["ElectricStorage"]["storage_to_load_series_kw"] .!= 0.0,
@@ -45,9 +48,6 @@ else  # run HiGHS tests
                     results["Outages"]["pv_to_storage_series_kw"] .!= 0.0
                 )
                 ) ≈ false
-            finalize(backend(model))
-            empty!(model)
-            GC.gc()
         end
         @testset "hybrid profile" begin
             electric_load = REopt.ElectricLoad(; 
@@ -744,6 +744,9 @@ else  # run HiGHS tests
             results = run_reopt(m, "./scenarios/thermal_load.json")
         
             @test round(results["ExistingBoiler"]["annual_fuel_consumption_mmbtu"], digits=0) ≈ 12904
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
             
             # Hourly fuel load inputs with addressable_load_fraction are served as expected
             data = JSON.parsefile("./scenarios/thermal_load.json")
@@ -810,6 +813,9 @@ else  # run HiGHS tests
             
                 @test round(results["CHP"]["size_kw"], digits=0) ≈ 263.0 atol=50.0
                 @test round(results["Financial"]["lcc"], digits=0) ≈ 1.11e7 rtol=0.05
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
 
                 # Test constrained CAPEX
                 initial_capex_no_incentives = results["Financial"]["initial_capital_costs"]
@@ -818,6 +824,9 @@ else  # run HiGHS tests
                 data_sizing["Financial"]["min_initial_capital_costs_before_incentives"] = min_capex
                 results = run_reopt(model, data_sizing)
                 @test results["Financial"]["initial_capital_costs"] ≈ min_capex rtol=1e-5
+                finalize(backend(model))
+                empty!(model)
+                GC.gc()                
             end
         
             @testset "CHP Cost Curve and Min Allowable Size" begin
@@ -879,7 +888,7 @@ else  # run HiGHS tests
                 @test results["CHP"]["size_kw"] ≈ data_cost_curve["CHP"]["min_allowable_kw"] atol=0.1
                 finalize(backend(m))
                 empty!(m)
-                GC.gc()                    
+                GC.gc()
             end
         
             @testset "CHP Unavailability and Outage" begin
@@ -938,7 +947,7 @@ else  # run HiGHS tests
                 @test sum(chp_total_elec_prod[unavail_2_start:unavail_2_end]) == 0.0  
                 finalize(backend(m))
                 empty!(m)
-                GC.gc()                 
+                GC.gc()
             end
         
             @testset "CHP Supplementary firing and standby" begin
@@ -984,7 +993,7 @@ else  # run HiGHS tests
                 empty!(m1)
                 finalize(backend(m2))
                 empty!(m2)
-                GC.gc()                 
+                GC.gc()
             end
 
             @testset "CHP to Waste Heat" begin
@@ -1012,7 +1021,7 @@ else  # run HiGHS tests
                 empty!(m1)
                 finalize(backend(m2))
                 empty!(m2)
-                GC.gc()                  
+                GC.gc()
             end
         end
         
@@ -1058,25 +1067,40 @@ else  # run HiGHS tests
                 @test (occursin("not supported by the solver", string(r["Messages"]["errors"])) || occursin("REopt scenarios solved either with errors or non-optimal solutions", string(r["Messages"]["errors"])))
                 # @test Meta.parse(r["FlexibleHVAC"]["purchased"]) === false
                 # @test r["Financial"]["npv"] == 0
-        
+                finalize(backend(m1))
+                empty!(m1)
+                finalize(backend(m2))
+                empty!(m2)
+                GC.gc()
+                
                 # put in a time varying fuel cost, which should make purchasing the FlexibleHVAC system economical
                 # with flat ElectricTariff the ExistingChiller does not benefit from FlexibleHVAC
                 d["ExistingBoiler"]["fuel_cost_per_mmbtu"] = rand(Float64, (8760))*(50-5).+5;
                 m1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
                 m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
                 r = run_reopt([m1,m2], d)
-                @test (occursin("not supported by the solver", string(r["Messages"]["errors"])) || occursin("REopt scenarios solved either with errors or non-optimal solutions", string(r["Messages"]["errors"])))
+                @test (occursin("not supported by the solver", string(r["Messages"]["errors"])) || occursin("REopt scenarios solved either with errors or non-optimal solutions", string(r["Messages"]["errors"])))                
                 # all of the savings are from the ExistingBoiler fuel costs
                 # @test Meta.parse(r["FlexibleHVAC"]["purchased"]) === true
                 # fuel_cost_savings = r["ExistingBoiler"]["lifecycle_fuel_cost_after_tax_bau"] - r["ExistingBoiler"]["lifecycle_fuel_cost_after_tax"]
                 # @test fuel_cost_savings - d["FlexibleHVAC"]["installed_cost"] ≈ r["Financial"]["npv"] atol=0.1
-        
+                finalize(backend(m1))
+                empty!(m1)
+                finalize(backend(m2))
+                empty!(m2)
+                GC.gc()        
+
                 # now increase the FlexibleHVAC installed_cost to the fuel costs savings + 100 and expect that the FlexibleHVAC is not purchased
                 # d["FlexibleHVAC"]["installed_cost"] = fuel_cost_savings + 100
                 m1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
                 m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
                 r = run_reopt([m1,m2], d)
                 @test (occursin("not supported by the solver", string(r["Messages"]["errors"])) || occursin("REopt scenarios solved either with errors or non-optimal solutions", string(r["Messages"]["errors"])))
+                finalize(backend(m1))
+                empty!(m1)
+                finalize(backend(m2))
+                empty!(m2)
+                GC.gc()                
                 # @test Meta.parse(r["FlexibleHVAC"]["purchased"]) === false
                 # @test r["Financial"]["npv"] == 0
         
@@ -1087,7 +1111,12 @@ else  # run HiGHS tests
                 m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
                 r = run_reopt([m1,m2], d)
                 @test (occursin("not supported by the solver", string(r["Messages"]["errors"])) || occursin("REopt scenarios solved either with errors or non-optimal solutions", string(r["Messages"]["errors"])))
-                
+                finalize(backend(m1))
+                empty!(m1)
+                finalize(backend(m2))
+                empty!(m2)
+                GC.gc()                
+
                 # elec_cost_savings = r["ElectricTariff"]["lifecycle_demand_cost_after_tax_bau"] + 
                 #                     r["ElectricTariff"]["lifecycle_energy_cost_after_tax_bau"] - 
                 #                     r["ElectricTariff"]["lifecycle_demand_cost_after_tax"] - 
@@ -1109,7 +1138,7 @@ else  # run HiGHS tests
                 empty!(m1)
                 finalize(backend(m2))
                 empty!(m2)
-                GC.gc()          
+                GC.gc()
             end
         end
 
@@ -1136,7 +1165,7 @@ else  # run HiGHS tests
                     if results["PV"]["electric_to_grid_series_kw"][i] > 0)
             finalize(backend(model))
             empty!(model)
-            GC.gc()                          
+            GC.gc()
         end
 
         #=
@@ -1209,7 +1238,7 @@ else  # run HiGHS tests
             empty!(m1)
             finalize(backend(m2))
             empty!(m2)
-            GC.gc()             
+            GC.gc()
 
             # compare avg soc with and without degradation, 
             # using default augmentation battery maintenance strategy
@@ -1221,6 +1250,9 @@ else  # run HiGHS tests
             r_degr = run_reopt(m, d)
             avg_soc_degr = sum(r_degr["ElectricStorage"]["soc_series_fraction"]) / 8760
             @test avg_soc_no_degr > avg_soc_degr
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
 
             # test the replacement strategy ## Cannot test with open source solvers.
             # d["ElectricStorage"]["degradation"] = Dict("maintenance_strategy" => "replacement")
@@ -1244,7 +1276,7 @@ else  # run HiGHS tests
             @test round(sum(r["ElectricStorage"]["soc_series_fraction"])/8760, digits=2) >= 0.72
             finalize(backend(m))
             empty!(m)
-            GC.gc()             
+            GC.gc()
         end
 
         @testset "Outage with Generator, outage simulator, BAU critical load outputs" begin
@@ -1264,7 +1296,7 @@ else  # run HiGHS tests
             empty!(m1)
             finalize(backend(m2))
             empty!(m2)
-            GC.gc()               
+            GC.gc()
         end
 
         @testset "Minimize Unserved Load" begin
@@ -1280,7 +1312,7 @@ else  # run HiGHS tests
             @test value(m[:binMGStorageUsed]) ≈ 1
             finalize(backend(m))
             empty!(m)
-            GC.gc()                 
+            GC.gc()
         
             # Increase cost of microgrid upgrade and PV Size, PV not used and some load not met
             d["Financial"]["microgrid_upgrade_cost_fraction"] = 0.3
@@ -1292,7 +1324,7 @@ else  # run HiGHS tests
             @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 24.16 atol=0.1
             finalize(backend(m))
             empty!(m)
-            GC.gc()                 
+            GC.gc()
             
             #=
             Scenario with $0.001/kWh value_of_lost_load_per_kwh, 12x169 hour outages, 1kW load/hour, and min_resil_time_steps = 168
@@ -1303,7 +1335,7 @@ else  # run HiGHS tests
             @test sum(results["Outages"]["unserved_load_per_outage_kwh"]) ≈ 12
             finalize(backend(m))
             empty!(m)
-            GC.gc()                 
+            GC.gc()
             
             # testing dvUnserved load, which would output 100 kWh for this scenario before output fix
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
@@ -1313,7 +1345,7 @@ else  # run HiGHS tests
             @test results["Outages"]["max_outage_cost_per_outage_duration"][1] ≈ 161.8109 atol=1.0e-5
             finalize(backend(m))
             empty!(m)
-            GC.gc()                 
+            GC.gc()
 
             # Scenario with generator, PV, electric storage
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
@@ -1322,7 +1354,7 @@ else  # run HiGHS tests
             @test results["Financial"]["lcc"] ≈ 8.63559824639e7 rtol=0.001
             finalize(backend(m))
             empty!(m)
-            GC.gc()                 
+            GC.gc()
 
             # Scenario with generator, PV, wind, electric storage
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
@@ -1334,7 +1366,7 @@ else  # run HiGHS tests
             @test results["Financial"]["lcc"] ≈ 4.833635288e6 rtol=0.001
             finalize(backend(m))
             empty!(m)
-            GC.gc()               
+            GC.gc()
         end
 
         @testset "Outages with Wind and supply-to-load no greater than critical load" begin
@@ -1358,7 +1390,7 @@ else  # run HiGHS tests
             empty!(m1)
             finalize(backend(m2))
             empty!(m2)
-            GC.gc()               
+            GC.gc()
         end
 
         @testset "Multiple Sites" begin
@@ -1369,6 +1401,9 @@ else  # run HiGHS tests
             ];
             results = run_reopt(m, ps)
             @test results[3]["Financial"]["lcc"] + results[10]["Financial"]["lcc"] ≈ 1.2830872235e7 rtol=1e-5
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         end
 
         @testset verbose=true "Rate Structures" begin
@@ -1379,6 +1414,9 @@ else  # run HiGHS tests
                 @test results["ElectricTariff"]["year_one_energy_cost_before_tax"] ≈ 2342.88
                 @test results["ElectricUtility"]["annual_energy_supplied_kwh"] ≈ 24000.0 atol=0.1
                 @test results["ElectricLoad"]["annual_calculated_kwh"] ≈ 24000.0 atol=0.1
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
             end
 
             @testset "Lookback Demand Charges" begin
@@ -1395,6 +1433,9 @@ else  # run HiGHS tests
                 # Expected result is 100 kW demand for January, 35% of that for all other months and 
                 # with 5x other $10.5/kW cold months and 6x $11.5/kW warm months
                 @test results["ElectricTariff"]["year_one_demand_cost_before_tax"] ≈ 100 * (10.5 + 0.35*10.5*5 + 0.35*11.5*6)
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
 
                 # 2. Testing custom rate from user with demand_lookback_months
                 d = JSON.parsefile("./scenarios/lookback_rate.json")
@@ -1416,6 +1457,9 @@ else  # run HiGHS tests
                 monthly_peaks = [300,300,300,400,300,500,300,300,300,300,300,300] # 300 = 400*0.75. Sets peak in all months excpet April and June
                 expected_demand_cost = sum(monthly_peaks.*d["ElectricTariff"]["monthly_demand_rates"]) 
                 @test r["ElectricTariff"]["year_one_demand_cost_before_tax"] ≈ expected_demand_cost
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
 
                 # 3. Testing custom rate from user with demand_lookback_range
                 d = JSON.parsefile("./scenarios/lookback_rate.json")
@@ -1437,6 +1481,9 @@ else  # run HiGHS tests
                 monthly_peaks = [225, 225, 225, 400, 300, 500, 375, 375, 375, 375, 375, 375]
                 expected_demand_cost = sum(monthly_peaks.*d["ElectricTariff"]["monthly_demand_rates"]) 
                 @test r["ElectricTariff"]["year_one_demand_cost_before_tax"] ≈ expected_demand_cost
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
 
             end
 
@@ -1445,12 +1492,18 @@ else  # run HiGHS tests
                 results = run_reopt(model, "./scenarios/no_techs.json")
                 @test results["ElectricTariff"]["year_one_energy_cost_before_tax"] ≈ 1000.0
                 @test results["ElectricTariff"]["year_one_demand_cost_before_tax"] ≈ 136.99
+                finalize(backend(model))
+                empty!(model)
+                GC.gc()
             end
 
             @testset "Coincident Peak Charges" begin
                 model = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
                 results = run_reopt(model, "./scenarios/coincident_peak.json")
                 @test results["ElectricTariff"]["year_one_coincident_peak_cost_before_tax"] ≈ 15.0
+                finalize(backend(model))
+                empty!(model)
+                GC.gc()
             end
 
             @testset "URDB sell rate" begin
@@ -1460,6 +1513,9 @@ else  # run HiGHS tests
                 p = REoptInputs("./scenarios/URDB_customer_generation.json")
                 results = run_reopt(model, p)
                 @test results["PV"]["size_kw"] ≈ p.max_sizes["PV"]
+                finalize(backend(model))
+                empty!(model)
+                GC.gc()
             end
 
             @testset "Custom URDB with Sub-Hourly" begin
@@ -1472,6 +1528,9 @@ else  # run HiGHS tests
                     results = run_reopt(model, p)
                     @test length(p.s.electric_tariff.export_rates[:WHL]) ≈ 8760*4
                     @test results["PV"]["size_kw"] ≈ p.s.pvs[1].existing_kw
+                    finalize(backend(model))
+                    empty!(model)
+                    GC.gc()
                 end
             end
 
@@ -1501,7 +1560,10 @@ else  # run HiGHS tests
                 tier1_rate = data["ElectricTariff"]["urdb_response"]["demandratestructure"][1][1]["rate"]
                 tier2_rate = data["ElectricTariff"]["urdb_response"]["demandratestructure"][1][2]["rate"]
                 expected_demand_charges = 12 * (tier1_max * tier1_rate + (max_demand - tier1_max) * tier2_rate)
-                @test results["ElectricTariff"]["year_one_demand_cost_before_tax"] ≈ expected_demand_charges atol=1                
+                @test results["ElectricTariff"]["year_one_demand_cost_before_tax"] ≈ expected_demand_charges atol=1
+                finalize(backend(model))
+                empty!(model)
+                GC.gc()                
             end
 
             # # tiered monthly demand rate  TODO: expected results?
@@ -1520,6 +1582,9 @@ else  # run HiGHS tests
                 m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
                 results = run_reopt(m, d)
                 @test occursin("URDB energy tiers have non-standard units of", string(results["Messages"]))
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
             end
 
         end
@@ -1538,6 +1603,9 @@ else  # run HiGHS tests
             results = run_reopt(m, d)
             @test results["Wind"]["size_kw"] ≈ 3752 atol=0.1
             @test results["Financial"]["lcc"] ≈ 8.591017e6 rtol=1e-5
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()            
             #= 
             0.5% higher LCC in this package as compared to API ? 8,591,017 vs 8,551,172
             - both have zero curtailment
@@ -1557,12 +1625,18 @@ else  # run HiGHS tests
             d["Site"]["land_acres"] = 60 # = 2 MW (with 0.03 acres/kW)
             results = run_reopt(m, d)
             @test results["Wind"]["size_kw"] == 2000.0 # Wind should be constrained by land_acres
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()            
 
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "presolve" => "on"))
             d["Wind"]["min_kw"] = 2001 # min_kw greater than land-constrained max should error
             results = run_reopt(m, d)
             @test "errors" ∈ keys(results["Messages"])
             @test length(results["Messages"]["errors"]) > 0
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()            
         end
 
         @testset "Multiple PVs" begin
@@ -1586,6 +1660,11 @@ else  # run HiGHS tests
                 @test ground_pv["annual_energy_produced_kwh"] ≈ 26799.26 atol=0.1
                 @test roof_west["annual_energy_produced_kwh"] ≈ 10719.51 atol=0.1
                 @test roof_east["annual_energy_produced_kwh"] ≈ 6685.95 atol=0.1
+                finalize(backend(m1))
+                empty!(m1)
+                finalize(backend(m2))
+                empty!(m2)
+                GC.gc()
             end
         end
 
@@ -1650,6 +1729,9 @@ else  # run HiGHS tests
             @test r["ExistingChiller"]["annual_thermal_production_tonhour"] ≈ 0.0 atol=0.1
             @test r["AbsorptionChiller"]["annual_thermal_production_tonhour"] ≈ 12464.15 atol=0.1
             @test r["AbsorptionChiller"]["size_ton"] ≈ 2.846 atol=0.01
+            finalize(backend(model))
+            empty!(model)
+            GC.gc()
         end
 
         @testset "Heat and cool energy balance" begin
@@ -1735,6 +1817,9 @@ else  # run HiGHS tests
             absorpchl_cop = absorpchl_cool_out_kwh / absorpchl_heat_in_kwh
 
             @test round(absorpchl_cop, digits=5) ≈ 0.8*0.7 rtol=1e-4
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         end
 
         @testset "Heating and cooling inputs + CHP defaults" begin
@@ -1980,6 +2065,11 @@ else  # run HiGHS tests
             # in February (28 days), so expect ExistingBoiler to serve the flat/constant load 28 days of the year
             @test existing_boiler_mmbtu ≈ load_thermal_mmbtu_bau * 28 / 365 atol=0.00001
             @test boiler_thermal_mmbtu ≈ load_thermal_mmbtu_bau - existing_boiler_mmbtu atol=0.00001
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()
         end
 
         @testset "OffGrid" begin
@@ -2018,6 +2108,9 @@ else  # run HiGHS tests
             post["PV"]["max_kw"] = 0.0
             post["ElectricStorage"]["max_kw"] = 0.0
             post["Generator"]["min_turn_down_fraction"] = 0.0
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()            
 
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
             r = run_reopt(m, post)
@@ -2043,12 +2136,18 @@ else  # run HiGHS tests
             post["PV"]["max_kw"] = 0.0
             post["ElectricStorage"]["max_kw"] = 0.0
             post["Generator"]["min_turn_down_fraction"] = 0.0
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()            
 
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
             r = run_reopt(m, post)
 
             # Test generator outputs
             @test typeof(r) == Model # this is true when the model is infeasible
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()            
 
             ### Scenario 3: Indonesia. Wind (custom prod) and Generator only
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.01, "presolve" => "on"))
@@ -2072,6 +2171,9 @@ else  # run HiGHS tests
             windOR = sum(results["Wind"]["electric_to_load_series_kw"]  * post["Wind"]["operating_reserve_required_fraction"])
             loadOR = sum(post["ElectricLoad"]["loads_kw"] * scen.electric_load.operating_reserve_required_fraction)
             @test sum(results["ElectricLoad"]["offgrid_annual_oper_res_required_series_kwh"]) ≈ loadOR  + windOR atol=1.0
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()            
 
         end
 
@@ -2159,6 +2261,11 @@ else  # run HiGHS tests
             # Average COP which includes pump power should be lower than Heat Pump only COP specified by the map
             @test heating_cop_avg <= 4.0
             @test cooling_cop_avg <= 8.0
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()
 
             # Check GHP LCC calculation for URBANopt
             ghp_data = JSON.parsefile("scenarios/ghp_urbanopt.json")
@@ -2182,6 +2289,9 @@ else  # run HiGHS tests
             # GHX size must be 0
             @test boreholes ≈ 0.0 atol = 0.01
             @test boreholes_len ≈ 0.0 atol = 0.01
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
 
             # Check GHX LCC calculation for URBANopt
             ghx_data = JSON.parsefile("scenarios/ghx_urbanopt.json")
@@ -2202,6 +2312,9 @@ else  # run HiGHS tests
             @test ghp_size ≈ 0.0 atol = 0.01
             # LCCC should be around be around 52% of initial capital cost due to incentive and bonus
             @test ghx_lccc/ghx_lccc_initial ≈ 0.518 atol = 0.01
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         end
 
         @testset "Hybrid GHX and GHP calculated costs validation" begin
@@ -2244,6 +2357,11 @@ else  # run HiGHS tests
             @test abs(results["Financial"]["internal_rate_of_return"] - 0.258) < 0.01
 
             @test haskey(results["ExistingBoiler"], "year_one_fuel_cost_before_tax_bau")
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()
 
             ## Hybrid
             input_data["GHP"]["ghpghx_responses"] = [JSON.parsefile("scenarios/ghpghx_hybrid_results.json")]
@@ -2269,6 +2387,11 @@ else  # run HiGHS tests
             
             @test results["GHP"]["ghx_residual_value_present_value"] ≈ calculated_ghx_residual_value atol=0.1
             @test inputs.s.ghp_option_list[1].is_ghx_hybrid = true
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()            
 
             # Test centralized GHP cost calculations
             input_data_wwhp = JSON.parsefile("scenarios/ghp_inputs_wwhp.json")
@@ -2301,6 +2424,9 @@ else  # run HiGHS tests
             ghx_residual_value = value(m3[Symbol("ResidualGHXCapCost")])
             reopt_ghp_capex = results_wwhp["Financial"]["lifecycle_capital_costs"] + ghx_residual_value
             @test calculated_ghp_capex ≈ reopt_ghp_capex atol=300
+            finalize(backend(m3))
+            empty!(m3)
+            GC.gc()
         end
 
         @testset "Cambium Emissions" begin
@@ -2380,7 +2506,12 @@ else  # run HiGHS tests
             @test sum(scen.electric_utility.emissions_factor_series_lb_NOx_per_kwh) ≈ 0 
             @test sum(scen.electric_utility.emissions_factor_series_lb_SO2_per_kwh) ≈ 0 
             @test sum(scen.electric_utility.emissions_factor_series_lb_PM25_per_kwh) ≈ 0 
-        
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()
+            
         end
 
         @testset "Emissions and Renewable Energy Percent" begin
@@ -2519,6 +2650,11 @@ else  # run HiGHS tests
                     annual_heat_kwh = (results["CHP"]["annual_thermal_production_mmbtu"] + results["ExistingBoiler"]["annual_thermal_production_mmbtu"]) * REopt.KWH_PER_MMBTU
                     @test results["Site"]["onsite_renewable_energy_fraction_of_total_load"] ≈ annual_RE_kwh / (annual_heat_kwh + results["ElectricLoad"]["annual_electric_load_with_thermal_conversions_kwh"]) rtol=0.001
                 end
+                finalize(backend(m1))
+                empty!(m1)
+                finalize(backend(m2))
+                empty!(m2)
+                GC.gc()                
             end
         end
 
@@ -2541,6 +2677,10 @@ else  # run HiGHS tests
             
             @test results["ElectricUtility"]["annual_renewable_electricity_supplied_kwh"] ≈ gridRE rtol=1e-4
             @test results["Site"]["onsite_and_grid_renewable_electricity_fraction_of_elec_load"] ≈ ((onsiteRE+gridRE) / results["ElectricLoad"]["annual_calculated_kwh"]) rtol=1e-3
+            
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
 
             # TODO: Add tests with heating techs (ASHP or GHP) once AnnualEleckWh is updated
         end
@@ -2609,6 +2749,12 @@ else  # run HiGHS tests
             factor = input_data["ExistingBoiler"]["max_thermal_factor_on_peak_load"]
             boiler_capacity = maximum(load_boiler_thermal) * factor
             @test maximum(boiler_total) <= boiler_capacity
+
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()
         end
 
         @testset "All heating supply/demand/storage energy balance" begin
@@ -2713,6 +2859,9 @@ else  # run HiGHS tests
                     @test sum(tech_to_thermal_load[tech]["steamturbine"]) == 0.0
                 end
             end
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         end
 
         @testset "Electric Heater" begin
@@ -2730,6 +2879,9 @@ else  # run HiGHS tests
             @test results["ElectricHeater"]["annual_thermal_production_mmbtu"] ≈ 0.0 atol=0.1
             @test results["ElectricHeater"]["annual_electric_consumption_kwh"] ≈ 0.0 atol=0.1
             @test results["ElectricUtility"]["annual_energy_supplied_kwh"] ≈ 87600.0 atol=0.1
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()             
             
             d["ExistingBoiler"]["fuel_cost_per_mmbtu"] = 100
             d["ElectricHeater"]["installed_cost_per_mmbtu_per_hour"] = 1.0
@@ -2749,6 +2901,9 @@ else  # run HiGHS tests
             @test results["ElectricHeater"]["annual_electric_consumption_kwh"] ≈ annual_electric_heater_consumption rtol=1e-4
             @test results["ElectricUtility"]["annual_energy_supplied_kwh"] ≈ annual_energy_supplied rtol=1e-4
 
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         end
 
         @testset "ASHP" begin
@@ -2771,7 +2926,10 @@ else  # run HiGHS tests
                 d["ExistingBoiler"]["fuel_cost_per_mmbtu"] = 100
                 d["ASHPSpaceHeater"]["installed_cost_per_ton"] = 300
                 d["ASHPSpaceHeater"]["min_allowable_ton"] = 80.0
-                
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
+
                 s = Scenario(d)
                 p = REoptInputs(s)            
                 m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false))
@@ -2789,6 +2947,9 @@ else  # run HiGHS tests
                 d["CoolingLoad"] = Dict("thermal_loads_ton" => ones(8760)*0.1)
                 d["ExistingChiller"] = Dict("cop" => 0.5)
                 d["ASHPSpaceHeater"]["can_serve_cooling"] = true
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
 
                 s = Scenario(d)
                 p = REoptInputs(s)
@@ -2800,6 +2961,9 @@ else  # run HiGHS tests
                 @test results["ASHPSpaceHeater"]["size_ton"] ≈ 80.0 atol=0.01 #size increases when cooling load also served
                 @test results["ASHPSpaceHeater"]["annual_electric_consumption_kwh"] ≈ annual_ashp_consumption rtol=1e-4
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_tonhour"] ≈ 876.0 rtol=1e-4
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
             
                 #Case 4: ASHP used for everything because the existing boiler and chiller are retired even if efficient or free to operate
                 d["ExistingChiller"] = Dict("retire_in_optimal" => true, "cop" => 100)
@@ -2811,6 +2975,9 @@ else  # run HiGHS tests
                 results = run_reopt(m, p)
                 @test results["ASHPSpaceHeater"]["annual_electric_consumption_kwh"] ≈ annual_ashp_consumption rtol=1e-4
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_tonhour"] ≈ 876.0 atol=1e-4
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
 
             end
 
@@ -2833,6 +3000,9 @@ else  # run HiGHS tests
                 d["ExistingBoiler"]["retire_in_optimal"] = false
                 d["ExistingBoiler"]["fuel_cost_per_mmbtu"] = 100
                 d["ASHPWaterHeater"]["installed_cost_per_ton"] = 300
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
                           
                 s = Scenario(d)
                 p = REoptInputs(s)
@@ -2845,6 +3015,9 @@ else  # run HiGHS tests
                 @test results["ASHPWaterHeater"]["annual_thermal_production_mmbtu"] ≈ annual_thermal_prod rtol=1e-4
                 @test results["ASHPWaterHeater"]["annual_electric_consumption_kwh"] ≈ annual_ashp_consumption rtol=1e-4
                 @test results["ElectricUtility"]["annual_energy_supplied_kwh"] ≈ annual_energy_supplied rtol=1e-4
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
             end
 
             @testset "Force in ASHP systems" begin
@@ -2867,6 +3040,9 @@ else  # run HiGHS tests
                 @test results["ASHPWaterHeater"]["annual_electric_consumption_kwh"] ≈ sum(0.4 * REopt.KWH_PER_MMBTU / p.heating_cop["ASHPWaterHeater"][ts] for ts in p.time_steps) rtol=1e-4
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_mmbtu"] ≈ 0.4 * 8760 rtol=1e-4
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_tonhour"] ≈ 876.0 rtol=1e-4
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
 
                 d["ASHPSpaceHeater"]["force_into_system"] = false
                 s = Scenario(d)
@@ -2877,6 +3053,9 @@ else  # run HiGHS tests
                 @test results["ASHPWaterHeater"]["annual_electric_consumption_kwh"] ≈ sum(0.4 * REopt.KWH_PER_MMBTU / p.heating_cop["ASHPWaterHeater"][ts] for ts in p.time_steps) rtol=1e-4
                 @test results["ExistingBoiler"]["annual_thermal_production_mmbtu"] ≈ 0.4 * 8760 rtol=1e-4
                 @test results["ExistingChiller"]["annual_thermal_production_tonhour"] ≈ 876.0 rtol=1e-4
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
 
                 d["ASHPSpaceHeater"]["force_into_system"] = true
                 d["ASHPWaterHeater"]["force_into_system"] = false
@@ -2888,6 +3067,9 @@ else  # run HiGHS tests
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_mmbtu"] ≈ 0.4 * 8760 rtol=1e-4
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_tonhour"] ≈ 876.0 rtol=1e-4
                 @test results["ExistingBoiler"]["annual_thermal_production_mmbtu"] ≈ 0.4 * 8760 rtol=1e-4
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
             end
 
             @testset "ASHP Forced Dispatch to Load or Max Capacity" begin
@@ -2913,6 +3095,9 @@ else  # run HiGHS tests
                 # This confirms that ASHPSpaceHeater is forced to dispatch to cooling load because the default ExistingChiller.cop is greater than the defaul ASHP cooling COP
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_tonhour"] ≈ 0.1 * 8760 rtol=1e-4
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_mmbtu"] ≈ 0.4 * 8760 rtol=1e-4            
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
                 
                 d["ASHPSpaceHeater"]["can_serve_cooling"] = false
                 d["ASHPSpaceHeater"]["min_ton"] = 10
@@ -2930,6 +3115,9 @@ else  # run HiGHS tests
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_mmbtu"] ≈ sum(10 * (REopt.KWH_THERMAL_PER_TONHOUR/REopt.KWH_PER_MMBTU) * p.heating_cf["ASHPSpaceHeater"][ts] for ts in p.time_steps) rtol=1e-4
                 @test results["ASHPWaterHeater"]["annual_electric_consumption_kwh"] ≈ sum(10 * REopt.KWH_THERMAL_PER_TONHOUR * p.heating_cf["ASHPWaterHeater"][ts] / p.heating_cop["ASHPWaterHeater"][ts] for ts in p.time_steps) rtol=1e-4
                 @test results["ASHPWaterHeater"]["annual_thermal_production_mmbtu"] ≈ sum(10 * (REopt.KWH_THERMAL_PER_TONHOUR/REopt.KWH_PER_MMBTU) * p.heating_cf["ASHPWaterHeater"][ts] for ts in p.time_steps) rtol=1e-4
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
             
                 d["ASHPSpaceHeater"]["force_dispatch"] = false
                 d["ASHPWaterHeater"]["force_dispatch"] = false
@@ -2944,6 +3132,9 @@ else  # run HiGHS tests
                 @test results["ASHPSpaceHeater"]["annual_thermal_production_mmbtu"] ≈ 0.0 atol=1e-4
                 @test results["ASHPWaterHeater"]["annual_electric_consumption_kwh"] ≈ 0.0 atol=1e-4
                 @test results["ASHPWaterHeater"]["annual_thermal_production_mmbtu"] ≈ 0.0 atol=1e-4
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
             
                 #Case 4: confirm that when force_dispatch == true, there is no ASHP system purchased when system is expensive compared to cost of fuel
                 d["ASHPSpaceHeater"]["force_dispatch"] = true
@@ -2956,6 +3147,9 @@ else  # run HiGHS tests
                 results = run_reopt(m, p)
                 @test results["ASHPSpaceHeater"]["size_ton"] ≈ 0.0 atol=1e-4
                 @test results["ASHPWaterHeater"]["size_ton"] ≈ 0.0 atol=1e-4
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
             end
         end
 
@@ -2979,6 +3173,9 @@ else  # run HiGHS tests
             @test sum(results["ExistingBoiler"]["thermal_to_space_heating_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=0.1
             @test sum(results["ExistingBoiler"]["thermal_to_process_heat_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=0.1
             @test results["ElectricUtility"]["annual_energy_supplied_kwh"] ≈ 0.0 atol=0.1
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         
             #Test set 2: Boiler only serves process heat
             d["Boiler"]["can_serve_dhw"] = false
@@ -2997,6 +3194,9 @@ else  # run HiGHS tests
             @test sum(results["ExistingBoiler"]["thermal_to_dhw_load_series_mmbtu_per_hour"]) ≈ 70080.0 atol=0.1
             @test sum(results["ExistingBoiler"]["thermal_to_space_heating_load_series_mmbtu_per_hour"]) ≈ 70080.0 atol=0.1
             @test sum(results["ExistingBoiler"]["thermal_to_process_heat_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=0.1
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         
             #Test set 3: Boiler cannot serve process heat but serves DHW, space heating
             d["Boiler"]["can_serve_dhw"] = true
@@ -3015,6 +3215,9 @@ else  # run HiGHS tests
             @test sum(results["ExistingBoiler"]["thermal_to_dhw_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=0.1
             @test sum(results["ExistingBoiler"]["thermal_to_space_heating_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=0.1
             @test sum(results["ExistingBoiler"]["thermal_to_process_heat_load_series_mmbtu_per_hour"]) ≈ 70080.0 atol=0.1
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         
             #Test set 4: Fuel expensive, but ExistingBoiler is retired
             d["Boiler"]["can_serve_dhw"] = true
@@ -3035,6 +3238,9 @@ else  # run HiGHS tests
             @test sum(results["ExistingBoiler"]["thermal_to_dhw_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=0.1
             @test sum(results["ExistingBoiler"]["thermal_to_space_heating_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=0.1
             @test sum(results["ExistingBoiler"]["thermal_to_process_heat_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=0.1
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         
             #Test set 5: Fuel expensive, ExistingBoiler not retired
             d["ExistingBoiler"]["retire_in_optimal"] = false
@@ -3051,7 +3257,10 @@ else  # run HiGHS tests
             @test sum(results["ExistingBoiler"]["thermal_to_dhw_load_series_mmbtu_per_hour"]) ≈ 70080.0 atol=0.1
             @test sum(results["ExistingBoiler"]["thermal_to_space_heating_load_series_mmbtu_per_hour"]) ≈ 70080.0 atol=0.1
             @test sum(results["ExistingBoiler"]["thermal_to_process_heat_load_series_mmbtu_per_hour"]) ≈ 70080.0 atol=0.1
-        
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
+    
             # Test 6: reduce emissions by half, get half the new boiler size
             d["Site"]["CO2_emissions_reduction_min_fraction"] = 0.50
             s = Scenario(d)
@@ -3062,6 +3271,11 @@ else  # run HiGHS tests
             @test results["Boiler"]["size_mmbtu_per_hour"] ≈ 12.0 atol=0.1
             @test results["Boiler"]["annual_thermal_production_mmbtu"] ≈ 105120.0 atol=0.1
             @test results["ExistingBoiler"]["annual_thermal_production_mmbtu"] ≈ 105120.0 atol=0.1
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()             
         end
 
         @testset "Custom REopt logger" begin
@@ -3079,6 +3293,11 @@ else  # run HiGHS tests
             @test length(r["Messages"]["errors"]) > 0
             @test length(r["Messages"]["warnings"]) > 0
             @test r["Messages"]["has_stacktrace"] == false
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()
 
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
             r = run_reopt(m, d)
@@ -3091,6 +3310,9 @@ else  # run HiGHS tests
 
             # Type is dict when errors, otherwise type REoptInputs
             @test isa(REoptInputs(d), Dict)
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()            
 
             # Using filepath
             n1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
@@ -3102,6 +3324,11 @@ else  # run HiGHS tests
             @test "warnings" ∈ keys(r["Messages"])
             @test length(r["Messages"]["errors"]) > 0
             @test length(r["Messages"]["warnings"]) > 0
+            finalize(backend(n1))
+            empty!(n1)
+            finalize(backend(n2))
+            empty!(n2)
+            GC.gc()
 
             n = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
             r = run_reopt(n, "./scenarios/logger.json")
@@ -3111,6 +3338,9 @@ else  # run HiGHS tests
             @test "warnings" ∈ keys(r["Messages"])
             @test length(r["Messages"]["errors"]) > 0
             @test length(r["Messages"]["warnings"]) > 0
+            finalize(backend(n))
+            empty!(n)
+            GC.gc()
 
             # Throw an unhandled error: Bad URDB rate -> stack gets returned for debugging
             d["ElectricLoad"]["doe_reference_name"] = "MidriseApartment"
@@ -3125,6 +3355,11 @@ else  # run HiGHS tests
             @test "warnings" ∈ keys(r["Messages"])
             @test length(r["Messages"]["errors"]) > 0
             @test length(r["Messages"]["warnings"]) > 0
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()
 
             m = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
             r = run_reopt(m, d)
@@ -3137,6 +3372,9 @@ else  # run HiGHS tests
 
             # Type is dict when errors, otherwise type REoptInputs
             @test isa(REoptInputs(d), Dict)
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
 
             # Using filepath
             n1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
@@ -3148,6 +3386,11 @@ else  # run HiGHS tests
             @test "warnings" ∈ keys(r["Messages"])
             @test length(r["Messages"]["errors"]) > 0
             @test length(r["Messages"]["warnings"]) > 0
+            finalize(backend(n1))
+            empty!(n1)
+            finalize(backend(n2))
+            empty!(n2)
+            GC.gc()
 
             n = Model(optimizer_with_attributes(HiGHS.Optimizer, "output_flag" => false, "log_to_console" => false, "mip_rel_gap" => 0.1))
             r = run_reopt(n, "./scenarios/logger.json")
@@ -3157,6 +3400,9 @@ else  # run HiGHS tests
             @test "warnings" ∈ keys(r["Messages"])
             @test length(r["Messages"]["errors"]) > 0
             @test length(r["Messages"]["warnings"]) > 0
+            finalize(backend(n))
+            empty!(n)
+            GC.gc()
         end
 
         @testset "Normalize and scale load profile input to annual and monthly energy" begin
@@ -3280,7 +3526,9 @@ else  # run HiGHS tests
             r = run_reopt(m, inputs)
             # Test battery size_kwh = size_hw * duration
             @test r["ElectricStorage"]["size_kw"]*8 - r["ElectricStorage"]["size_kwh"] ≈ 0.0 atol = 0.1
-
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()
         end
 
         @testset "Test leap year for URDB demand and energy charges" begin
@@ -3328,6 +3576,9 @@ else  # run HiGHS tests
                 end
                 @test results["ElectricTariff"]["year_one_energy_cost_before_tax"] ≈ energy_charge_expected atol=1E-6
                 @test results["ElectricTariff"]["year_one_demand_cost_before_tax"] ≈ demand_charge_expected atol=1E-6
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
 
                 # Flat/facility (non-TOU) demand charge
                 input_data["ElectricLoad"]["loads_kw"] = zeros(8760)
@@ -3346,6 +3597,9 @@ else  # run HiGHS tests
                     demand_charge_expected = 2 * flat_rate * peak_load
                 end
                 @test results["ElectricTariff"]["year_one_demand_cost_before_tax"] ≈ demand_charge_expected atol=1E-6
+                finalize(backend(m))
+                empty!(m)
+                GC.gc()
             end
         end
 
@@ -3390,6 +3644,9 @@ else  # run HiGHS tests
             sim_load_response = simulated_load(d_sim_load)
         
             @test sim_load_response["loads_mmbtu_per_hour"] ≈ round.(heating_load, digits=3)
+            finalize(backend(m))
+            empty!(m)
+            GC.gc()            
         
             # If a non-2017 year is input with a CRB for electric, heating, or cooling load, make sure that 
             #  the energy input is preserved while the CRB profile is shifted and adjusted to align with 
@@ -3438,6 +3695,11 @@ else  # run HiGHS tests
             # Calculated payback from above-two metrics
             payback = capital_costs_after_non_discounted_incentives / savings
             @test round(results["Financial"]["simple_payback_years"], digits=2) ≈ round(payback, digits=2)
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()
 
             # Test that with a non-zero discount rate, as long as the battery replacement cost is zero, these payback periods should also align
             input_data["Financial"]["offtaker_discount_rate_fraction"] = 0.1
@@ -3450,6 +3712,11 @@ else  # run HiGHS tests
             results = run_reopt([m1,m2], inputs)
             payback = results["Financial"]["capital_costs_after_non_discounted_incentives"] / results["Financial"]["year_one_total_operating_cost_savings_after_tax"]
             @test round(results["Financial"]["simple_payback_years"], digits=2) ≈ round(payback, digits=2)
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+            GC.gc()
         end
     end
 end


### PR DESCRIPTION
Speed up runtests.jl job in GitHub Actions by clearing the memory buildup from the optimization models.

Also attempted to use the ubuntu (linux) runner and the macos-latest-large (more memory (32 GB) Mac OS), and confirmed that those are still not working.