### PR TITLE
Fix issue with No-Incentive CapEx calc

### DIFF
--- a/src/constraints/cost_curve_constraints.jl
+++ b/src/constraints/cost_curve_constraints.jl
@@ -165,7 +165,7 @@ function initial_capex_no_incentives(m::JuMP.AbstractModel, p::REoptInputs; _n="
         size_list = p.s.chp.tech_sizes_for_cost_curve
 
         t="CHP"
-        if t in p.techs.segmented
+        if t in p.techs.segmented && !isempty(size_list)
             # Use "no incentives" version of p.cap_cost_slope and p.seg_yint
             cost_slope_no_inc = [cost_list[1]]
             seg_yint_no_inc = [0.0]


### PR DESCRIPTION
Fixes an issue that was found soon after CapEx constraint was deployed to the web tool, where the user inputs a rebate incentive with a maximum value for CHP (which has a default 2-pt cost curve), which causes n_segs to be greater than the non-incentive cost curve.

This would also be an issue with PV with a 2-pt cost curve where there is also an incentive with a maximum value.