### PR TITLE
Update rate_effective_date URDB response

### DIFF
--- a/src/core/urdb.jl
+++ b/src/core/urdb.jl
@@ -86,7 +86,7 @@ function URDBrate(urdb_response::Dict, year::Int; time_steps_per_hour=1)
     label = get(urdb_response, "label", "")
     rate_name = get(urdb_response, "name", "")
     utility = get(urdb_response, "utility", "")
-    latest_update_unix = get(urdb_response, "latest_update", 0.0)
+    latest_update_unix = get(urdb_response, "startdate", 0.0)
     voltage_level = get(urdb_response, "voltagecategory", "")
     rate_description = get(urdb_response, "description", "")
     peak_kw_capacity_min = get(urdb_response, "peakkwcapacitymin", 0.0)  
@@ -96,10 +96,10 @@ function URDBrate(urdb_response::Dict, year::Int; time_steps_per_hour=1)
     demand_comments = get(urdb_response, "demandcomments", "")
     url_link = get(urdb_response, "uri", "")
 
-    # Convert Unix timestamp to datetime string
+    # Convert Unix timestamp to date string
     rate_effective_date = ""
     if latest_update_unix > 0
-        rate_effective_date = string(Dates.unix2datetime(latest_update_unix))
+        rate_effective_date = string(Date(Dates.unix2datetime(latest_update_unix)))
     end
 
     # Convert matrix to array if needed


### PR DESCRIPTION
Changed the URDB variable that rate_effective_date references from 'latest_update' to 'startdate'. Also, changed the output to be a date string instead of a datetime string.