### PR TITLE
Update logging.jl

### DIFF
--- a/src/logging.jl
+++ b/src/logging.jl
@@ -79,7 +79,13 @@ function Logging.handle_message(logger::REoptLogger, lvl, msg, _mod, group, id, 
         end
         
         splt = split(file, splitter)
-        f = join([splt[end-1], splt[end], line], "_")
+        # Guard against short paths; Julia arrays are 1-based so end-1 can underflow
+        if length(splt) >= 2
+            f = join([splt[end-1], splt[end], line], "_")
+        else
+            # Use just the filename when no parent directory is present
+            f = join([splt[end], line], "_")
+        end
 
         if f ∉ keys(logger.d[string(lvl)]) #file name doesnt exists
             logger.d[string(lvl)][f] = Any[]


### PR DESCRIPTION
This pull request adds a small but important fix to the logging functionality to handle edge cases with file paths. Specifically, it ensures that log file naming works correctly even when the file path does not include a parent directory.

Logging robustness improvements:

* In the `Logging.handle_message` function in `src/logging.jl`, added a guard to handle cases where the file path is too short (i.e., lacks a parent directory), so that log file names are generated correctly without causing indexing errors.