### PR TITLE
CHP Ramp Rate Limitation Option

### DIFF
--- a/src/constraints/chp_constraints.jl
+++ b/src/constraints/chp_constraints.jl
@@ -135,6 +135,22 @@ function add_chp_rated_prod_constraint(m, p; _n="")
 end
 
 
+function add_chp_ramp_rate_constraints(m, p; _n="")
+    # Ramp rate constraints limit how quickly CHP production can change between consecutive timesteps
+    # Ramp up constraint
+    @constraint(m, CHPRampUp[t in p.techs.chp, ts in p.time_steps[2:end]],
+        m[Symbol("dvRatedProduction"*_n)][t, ts] - m[Symbol("dvRatedProduction"*_n)][t, ts-1] <=
+        p.s.chp.ramp_rate_fraction_per_hour * m[Symbol("dvSize"*_n)][t] / p.s.settings.time_steps_per_hour
+    )
+    
+    # Ramp down constraint
+    @constraint(m, CHPRampDown[t in p.techs.chp, ts in p.time_steps[2:end]],
+        m[Symbol("dvRatedProduction"*_n)][t, ts-1] - m[Symbol("dvRatedProduction"*_n)][t, ts] <=
+        p.s.chp.ramp_rate_fraction_per_hour * m[Symbol("dvSize"*_n)][t] / p.s.settings.time_steps_per_hour
+    )
+end
+
+
 """
     add_chp_hourly_om_charges(m, p; _n="")
 
@@ -197,6 +213,11 @@ function add_chp_constraints(m, p; _n="")
     add_chp_thermal_production_constraints(m, p; _n=_n)
     add_binCHPIsOnInTS_constraints(m, p; _n=_n)
     add_chp_rated_prod_constraint(m, p; _n=_n)
+    
+    # Add ramp rate constraints if ramp_rate_fraction_per_hour < 1.0
+    if p.s.chp.ramp_rate_fraction_per_hour < 1.0 / p.s.settings.time_steps_per_hour
+        add_chp_ramp_rate_constraints(m, p; _n=_n)
+    end
 
     if p.s.chp.supplementary_firing_max_steam_ratio > 1.0
         add_chp_supplementary_firing_constraints(m,p; _n=_n)

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -30,6 +30,7 @@ conflict_res_min_allowable_fraction_of_max = 0.25
     fuel_type::String = "natural_gas" # "restrict_to": ["natural_gas", "landfill_bio_gas", "propane", "diesel_oil"]
     om_cost_per_kw::Float64 = 0.0 # Annual CHP fixed operations and maintenance costs in \$/kw-yr 
     om_cost_per_hr_per_kw_rated::Float64 = 0.0 # CHP non-fuel variable operations and maintenance costs in \$/hr/kw_rated
+    ramp_rate_fraction_per_hour::Float64 = 1.0 # Maximum rate of change in electric production per hour as a fraction of size_kw [kW/size_kw/hour].
     supplementary_firing_capital_cost_per_kw::Float64 = 150.0 # Installed CHP supplementary firing system cost in \$/kW (based on rated electric power)
     supplementary_firing_max_steam_ratio::Float64 = 1.0 # Ratio of max fired steam to un-fired steam production. Relevant only for combustion_turbine prime_mover 
     supplementary_firing_efficiency::Float64 = 0.92 # Thermal efficiency of the incremental steam production from supplementary firing. Relevant only for combustion_turbine prime_mover 
@@ -101,6 +102,7 @@ Base.@kwdef mutable struct CHP <: AbstractCHP
     fuel_type::String = "natural_gas"
     om_cost_per_kw::Float64 = 0.0
     om_cost_per_hr_per_kw_rated::Float64 = 0.0
+    ramp_rate_fraction_per_hour::Float64 = 1.0
     electric_efficiency_half_load::Float64 = NaN  # Assigned to electric_efficiency_full_load if not input
     thermal_efficiency_half_load::Float64 = NaN  # Assigned to thermal_efficiency_full_load if not input
     supplementary_firing_capital_cost_per_kw::Float64 = 150.0

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -223,6 +223,17 @@ function dictkeys_tosymbols(d::Dict)
                 end
             end
         end
+        # Convert numeric boolean values (0.0/1.0) to proper Bool type
+        if k in [
+            "off_grid_flag", "add_soc_incentive", "include_climate_in_objective", 
+            "include_health_in_objective", "include_export_cost_series_in_results"
+        ] && !isnothing(v) && !(typeof(v) <: Bool)
+            try
+                v = Bool(v)
+            catch
+                throw(@error("Unable to convert $k to Bool. Expected boolean or 0/1, got: $v"))
+            end
+        end
         if k in [
             "fuel_cost_per_mmbtu", "wholesale_rate", "export_rate_beyond_net_metering_limit",
             # for ERP

--- a/test/scenarios/nuclear_battery.json
+++ b/test/scenarios/nuclear_battery.json
@@ -1,0 +1,28 @@
+{
+    "Site": {
+        "latitude": 37.78, 
+        "longitude": -122.45
+    },
+    "ElectricLoad": {},
+    "ElectricTariff": {
+        "blended_annual_energy_rate": 0.12,
+        "blended_annual_demand_rate": 10.0
+    },
+    "CHP": {
+        "fuel_cost_per_mmbtu": 0.1,
+        "prime_mover": "combustion_turbine",
+        "installed_cost_per_kw": 12000.0,
+        "om_cost_per_kw": 150.0,
+        "om_cost_per_kwh": 0.0,
+        "electric_efficiency_full_load": 0.25,
+        "electric_efficiency_half_load": 0.25,
+        "min_turn_down_fraction": 0.0,
+        "is_electric_only": true,
+        "can_curtail": false,
+        "unavailability_periods": [{"month":1,
+                                    "start_week_of_month":2,
+                                    "start_day_of_week":1,
+                                    "start_hour":1, 
+                                    "duration_hours":0}]
+    }
+}

--- a/test/test_ramp.jl
+++ b/test/test_ramp.jl
@@ -1,0 +1,187 @@
+# using Revise
+# using REopt
+# using JSON
+# using DelimitedFiles
+# using PlotlyJS
+# using Dates
+# using Test
+# using JuMP
+# using HiGHS
+# using DotEnv
+# DotEnv.load!()
+
+# Notes to test for Off-Grid DC powered by Nuclear + Storage
+# 
+# DONE: CHP electric only with ramp rate limit, no outage but force battery size to avoid utility serving the high ramp times
+# Boiler + SteamTurbine (+ HighTempThermalStorage?)
+# Add CHP and/or Boiler+ST to off-grid with SR requirements for nuclear
+# Generator and Battery currently have unlimited SR **supply**
+# PV has SR requirement - use that as proxy for nuclear and/or geothermal?
+# Focus on analysis needs for project, but eventually consider GenericGenerator (+Heat?) with needed attributes
+
+
+# Create a 15-minute interval load profile from hourly with sine wave sub-hourly variations
+function upsample_load_variation(hourly_load; intra_hour_variation=0.2)
+    # Create 15-minute load profile with sine wave sub-hourly variations
+    fifteen_min_loads = Float64[]
+    for (hour_idx, hourly_load) in enumerate(hourly_load)
+        # Create 4 sub-hourly values per hour with sine wave variation
+        # Base load with ±10% sine wave variation within each hour
+        for quarter_hour in 1:4
+            # Intra-hour phase angle for this quarter hour (0, π/2, π, 3π/2)
+            intra_hour_phase = (quarter_hour - 1) * π / 2
+            # Sine wave variation: ±20% of hourly load
+            variation = intra_hour_variation * sin(intra_hour_phase + 2π * hour_idx / 24)  # Daily cycle component
+            sub_hourly_load = hourly_load * (1.0 + variation)
+            push!(fifteen_min_loads, max(0.0, sub_hourly_load))  # Ensure non-negative
+        end
+    end
+
+    return fifteen_min_loads
+end
+
+
+###############   Nuclear as CHP with ramp rate and battery to support   ###################
+
+# scenario = 1 # "Specify CHP+battery sizes 15-min load with variation, no outages"
+# scenario = 2 # "Least-cost sizes CHP+battery for year long outage hourly load from CRB"
+# scenario = 3 # "Force CHP/Nuclear to peak load size, but still size battery for ramp rate limit"
+scenario = 3
+# Load scenario with CHP (electric only) cost and performance params similar to nuclear
+input_data = JSON.parsefile("./scenarios/nuclear_battery.json")
+
+# New ramp rate input/constraint (fraction of capacity per hour)
+input_data["CHP"]["ramp_rate_fraction_per_hour"] = 0.1
+
+if scenario == 1
+    # Create 15-minute load profile from hourly with sine wave intra-hour variation
+    sim_input = Dict(
+        "load_type" => "electric",
+        "doe_reference_name" => "Hospital",
+        "annual_kwh" => 4.0e6,
+        "latitude" => input_data["Site"]["latitude"],
+        "longitude" => input_data["Site"]["longitude"],
+        "year" => 2023)
+    hourly_loads_kw = simulated_load(sim_input)["loads_kw"]
+    fifteen_min_loads = upsample_load_variation(hourly_loads_kw; intra_hour_variation=0.05)
+    input_data["Settings"] = Dict("time_steps_per_hour" => 4)
+    input_data["ElectricLoad"] = Dict("loads_kw" => fifteen_min_loads, "year" => 2023)
+
+    # You can adjust the fixed size here if desired
+    fixed_chp_size_kw = 800.0
+    input_data["CHP"]["min_kw"] = fixed_chp_size_kw
+    input_data["CHP"]["max_kw"] = fixed_chp_size_kw
+
+    # See if REopt sizes battery to support nuclear ramp rate limitation
+    input_data["ElectricStorage"] = Dict(
+        "min_kw" => 800.0,
+        "min_kwh" => 800.0,
+        "max_kw" => 800.0,
+        "max_kwh" => 800.0
+    )
+elseif scenario == 2 || scenario == 3
+    # Year-long outage scenario from CHP test scenarios
+    input_data["ElectricLoad"] = Dict("doe_reference_name" => "Hospital", "annual_kwh" => 4.0e6)
+    input_data["ElectricLoad"]["critical_load_fraction"] = 1.0
+    input_data["ElectricUtility"] = Dict("outage_start_time_step" => 1, 
+                                        "outage_end_time_step" => 8760)
+    input_data["ElectricStorage"] = Dict()
+    if scenario == 3
+        # Force CHP to peak load size, but still size battery for ramp rate limit
+        # Estimate peak load from annual energy assuming capacity factor
+        estimated_peak_load_kw = 740.0  # Assuming 50% capacity factor
+        input_data["CHP"]["min_kw"] = estimated_peak_load_kw
+        input_data["CHP"]["max_kw"] = estimated_peak_load_kw
+    end
+end
+
+# This was somehow being set to 0 in dictkeys_tosymbols in utils.py which was causing an error,
+# but function was updated to avoid this
+# input_data["Settings"]["off_grid_flag"] = false
+
+# Create scenario and inputs
+s = Scenario(input_data)
+inputs = REoptInputs(s)
+ts_per_hour = s.settings.time_steps_per_hour
+
+# Run optimization with single model (no BAU comparison needed for fixed sizing)
+m = Model(optimizer_with_attributes(HiGHS.Optimizer, "mip_rel_gap" => 0.01, "output_flag" => false, "log_to_console" => false))
+results = run_reopt(m, inputs)
+
+# Print key results
+println("\n===== Nuclear as CHP with ramp rate and battery to support  =====")
+println("\nCHP Results:")
+println("CHP Size (kW): ", results["CHP"]["size_kw"])
+println("Annual CHP Production (kWh): ", round(results["CHP"]["annual_electric_production_kwh"], digits=0))
+println("CHP to Load (kWh): ", round(sum(results["CHP"]["electric_to_load_series_kw"])/ts_per_hour, digits=0))
+println("CHP to Battery (kWh): ", round(sum(results["CHP"]["electric_to_storage_series_kw"])/ts_per_hour, digits=0))
+println("CHP to Grid (kWh): ", round(sum(results["CHP"]["electric_to_grid_series_kw"])/ts_per_hour, digits=0))
+println("CHP Curtailed (kWh): ", round(sum(results["CHP"]["electric_curtailed_series_kw"])/ts_per_hour, digits=0))
+println("\nBattery Results:")
+println("Battery Energy Size (kWh): ", results["ElectricStorage"]["size_kwh"])
+println("Battery Power Size (kW): ", results["ElectricStorage"]["size_kw"])
+println("Battery to Load (kWh): ", round(sum(results["ElectricStorage"]["storage_to_load_series_kw"])/ts_per_hour, digits=0))
+println("\nGrid Results:")
+println("Utility to Load (kWh): ", round(sum(results["ElectricUtility"]["annual_energy_supplied_kwh"]), digits=0))
+# println("\nFinancial Results:")
+# println("NPV (\$): ", round(results["Financial"]["npv"], digits=0))
+# println("Simple Payback (years): ", round(results["Financial"]["simple_payback_years"], digits=2))
+println("==========================================\n")
+
+# Create stacked area chart showing how CHP and battery serve the load
+load_series = results["ElectricLoad"]["load_series_kw"]
+chp_to_load = results["CHP"]["electric_to_load_series_kw"]
+batt_to_load = results["ElectricStorage"]["storage_to_load_series_kw"]
+grid_to_load = results["ElectricUtility"]["electric_to_load_series_kw"]
+
+# Create time steps array (in hours for x-axis)
+time_hours = collect(1:length(load_series)) ./ ts_per_hour
+
+# Create stacked area chart
+plt = plot(
+    [
+        scatter(
+            x=time_hours, 
+            y=grid_to_load, 
+            mode="lines", 
+            name="Grid to Load",
+            fill="tozeroy",
+            line=attr(width=0.5, color="rgb(128,128,128)"),
+            fillcolor="rgba(128,128,128,0.5)"
+        ),
+        scatter(
+            x=time_hours, 
+            y=grid_to_load .+ chp_to_load, 
+            mode="lines", 
+            name="CHP to Load",
+            fill="tonexty",
+            line=attr(width=0.5, color="rgb(255,128,0)"),
+            fillcolor="rgba(255,128,0,0.6)"
+        ),
+        scatter(
+            x=time_hours, 
+            y=grid_to_load .+ chp_to_load .+ batt_to_load, 
+            mode="lines", 
+            name="Battery to Load",
+            fill="tonexty",
+            line=attr(width=0.5, color="rgb(0,128,255)"),
+            fillcolor="rgba(0,128,255,0.6)"
+        ),
+        scatter(
+            x=time_hours, 
+            y=load_series, 
+            mode="lines", 
+            name="Total Load",
+            line=attr(width=2, color="rgb(0,0,0)", dash="dot")
+        )
+    ],
+    Layout(
+        title="Electric Load Service Breakdown - CHP with Ramp Rate and Battery Support",
+        xaxis=attr(title="Time (hours)", range=[0, 8760]),
+        yaxis=attr(title="Power (kW)"),
+        showlegend=true,
+        hovermode="x unified",
+        legend=attr(x=1.02, y=1, xanchor="left", yanchor="top")
+    )
+)
+display(plt)


### PR DESCRIPTION
This pull request introduces a new ramp rate constraint for Combined Heat and Power (CHP) systems, improves result reporting for curtailed electricity, and adds a new test scenario to validate these changes. The most significant updates are the implementation of CHP ramp rate constraints, enhancements to input parsing and result reporting, and the addition of a comprehensive nuclear battery scenario test.

**CHP Ramp Rate Constraints:**

* Added a new parameter `ramp_rate_fraction_per_hour` to the `CHP` struct and input parsing, allowing users to specify the maximum rate of change in CHP electric production per hour as a fraction of capacity. [[1]](diffhunk://#diff-af606daa7cdc70b47024c11c87713b0ad747e241d7a82518762516794f0b3b7bR33) [[2]](diffhunk://#diff-af606daa7cdc70b47024c11c87713b0ad747e241d7a82518762516794f0b3b7bR105)
* Implemented `add_chp_ramp_rate_constraints` in `chp_constraints.jl` to enforce ramp up and ramp down limits on CHP production between consecutive timesteps.
* Integrated ramp rate constraints into the main CHP constraint setup, activating them only when the ramp rate is less than the maximum possible per timestep.

**Result Reporting Improvements:**

* Updated `add_chp_results` to report curtailed electric output from CHP (`electric_curtailed_series_kw`) and subtract curtailment from the calculated CHP-to-load values for more accurate reporting.

**Input Handling Enhancements:**

* Improved the `dictkeys_tosymbols` utility to robustly convert numeric boolean values (0.0/1.0) to proper `Bool` types, preventing errors during input parsing.

**Testing and Validation:**

* Added a new test scenario file `nuclear_battery.json` and a comprehensive test script `test_ramp.jl` to simulate a nuclear-as-CHP system with ramp rate constraints and battery support, including plotting and result summaries. [[1]](diffhunk://#diff-44167954ca02de81152b01308afbf8ca124baf859100b2a1867c16e3f90405f2R1-R28) [[2]](diffhunk://#diff-a902febd02e0dd42fca0c8b7dad11948339f76e64ae476b64790319a418be77dR1-R187)