### PR TITLE
Fix Boiler Plus SteamTurbine Result

### DIFF
--- a/test/scenarios/boiler_steamturbine.json
+++ b/test/scenarios/boiler_steamturbine.json
@@ -1,0 +1,51 @@
+{
+    "Site": {
+        "latitude": 37.78,
+        "longitude": -122.45
+    },
+    "ElectricLoad": {
+        "doe_reference_name": "Hospital",
+        "annual_kwh": 5000000.0
+    },
+    "SpaceHeatingLoad": {
+        "doe_reference_name": "Hospital",
+        "annual_mmbtu": 10000.0
+    },
+    "DomesticHotWaterLoad": {
+        "doe_reference_name": "Hospital",
+        "annual_mmbtu": 2000.0
+    },
+    "ElectricTariff": {
+        "blended_annual_energy_rate": 0.10,
+        "blended_annual_demand_rate": 10.0
+    },
+    "ExistingBoiler":{
+        "fuel_cost_per_mmbtu": 8.0,
+        "efficiency": 0.75,
+        "can_supply_steam_turbine": false
+    },
+    "Boiler": {
+        "min_mmbtu_per_hour": 0.0,
+        "max_mmbtu_per_hour": 100.0,
+        "efficiency": 0.8,
+        "fuel_type": "natural_gas",
+        "fuel_cost_per_mmbtu": 8.0,
+        "installed_cost_per_mmbtu_per_hour": 50000.0,
+        "om_cost_per_mmbtu_per_hour": 500.0,
+        "om_cost_per_mmbtu": 0.5,
+        "can_supply_steam_turbine": true
+    },
+    "SteamTurbine": {
+        "min_kw": 0.0,
+        "max_kw": 5000.0,
+        "electric_produced_to_thermal_consumed_ratio": 0.30,
+        "thermal_produced_to_thermal_consumed_ratio": 0.50,
+        "installed_cost_per_kw": 1000.0,
+        "om_cost_per_kw": 10.0,
+        "om_cost_per_kwh": 0.01,
+        "can_wholesale": false,
+        "can_curtail": false,
+        "macrs_bonus_fraction": 0.0,
+        "macrs_option_years": 5
+    }
+}

--- a/test/test_boiler_steamturbine.jl
+++ b/test/test_boiler_steamturbine.jl
@@ -1,0 +1,47 @@
+using Revise
+using REopt
+using JSON
+using DelimitedFiles
+using PlotlyJS
+using Dates
+using Test
+using JuMP
+using HiGHS
+using DotEnv
+DotEnv.load!()
+
+###############   Boiler + SteamTurbine with simplified parameters   ###################
+# This test uses the simpler SteamTurbine setup with electric_produced_to_thermal_consumed_ratio
+# and thermal_produced_to_thermal_consumed_ratio instead of detailed steam parameters
+
+input_data = JSON.parsefile("./scenarios/boiler_steamturbine.json")
+s = Scenario(input_data)
+inputs = REoptInputs(s)
+
+m1 = Model(optimizer_with_attributes(HiGHS.Optimizer, "mip_rel_gap" => 0.001, "output_flag" => false, "log_to_console" => false))
+m2 = Model(optimizer_with_attributes(HiGHS.Optimizer, "mip_rel_gap" => 0.001, "output_flag" => false, "log_to_console" => false))
+results = run_reopt([m1,m2], inputs)
+
+println("\n=== Boiler + SteamTurbine Test Results ===")
+println("Financial NPV: ", round(results["Financial"]["npv"], digits=2))
+println("Financial LCC: ", round(results["Financial"]["lcc"], digits=2))
+println("\nBoiler:")
+println("  Size (MMBtu/hr): ", round(results["Boiler"]["size_mmbtu_per_hour"], digits=2))
+println("  Annual thermal production (MMBtu): ", round(results["Boiler"]["annual_thermal_production_mmbtu"], digits=2))
+println("  Annual fuel consumption (MMBtu): ", round(results["Boiler"]["annual_fuel_consumption_mmbtu"], digits=2))
+println("  Thermal to SteamTurbine (MMBtu): ", round(sum(results["Boiler"]["thermal_to_steamturbine_series_mmbtu_per_hour"]), digits=2))
+println("\nSteamTurbine:")
+println("  Size (kW): ", round(results["SteamTurbine"]["size_kw"], digits=2))
+println("  Annual electric production (kWh): ", round(results["SteamTurbine"]["annual_electric_production_kwh"], digits=2))
+println("  Annual thermal consumption (MMBtu): ", round(results["SteamTurbine"]["annual_thermal_consumption_mmbtu"], digits=2))
+println("  Annual thermal production (MMBtu): ", round(results["SteamTurbine"]["annual_thermal_production_mmbtu"], digits=2))
+
+# Verify energy balance: Boiler thermal to ST should match ST thermal consumption
+boiler_to_st = sum(results["Boiler"]["thermal_to_steamturbine_series_mmbtu_per_hour"])
+st_thermal_in = results["SteamTurbine"]["annual_thermal_consumption_mmbtu"]
+println("\nEnergy Balance Check:")
+println("  Boiler->SteamTurbine: ", round(boiler_to_st, digits=2), " MMBtu")
+println("  SteamTurbine thermal in: ", round(st_thermal_in, digits=2), " MMBtu")
+println("  Difference: ", round(abs(boiler_to_st - st_thermal_in), digits=2), " MMBtu")
+
+println("=============================================\n")


### PR DESCRIPTION
This pull request adds a new test scenario and makes important corrections to the boiler results calculations to ensure consistent units and accurate annual totals. The main focus is on improving the accuracy of boiler and steam turbine modeling and providing a new test case for validation.

**Corrections to Boiler Results Calculations:**

* The calculations for `annual_fuel_consumption_mmbtu` and `annual_thermal_production_mmbtu` in `add_boiler_results` now divide by `time_steps_per_hour` to correctly convert from per-timestep sums to annual totals in MMBtu.
* The `thermal_to_steamturbine_series_mmbtu_per_hour` output is now correctly converted to MMBtu by dividing by `KWH_PER_MMBTU`.

**New Test Scenario and Validation:**

* Added a new scenario file `boiler_steamturbine.json` that defines a site with boiler and steam turbine parameters for testing.
* Introduced a comprehensive test script `test_boiler_steamturbine.jl` that runs the scenario, prints key results, and checks the energy balance between boiler output and steam turbine input.