### PR TITLE
update documentation links to natlabrockies.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ REopt.jl is the core module of the [REopt® techno-economic decision support pla
 REopt.jl (this package) is used within the publicly-accessible and open-source [REopt API](https://github.com/NREL/REopt_API), and the publicly-available [REopt Web Tool](https://reopt.nrel.gov/tool) calls the REopt API.
 
 For more information about REopt.jl please see the Julia documentation:
-<!-- [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://nrel.github.io/REopt.jl/stable) -->
-[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://nrel.github.io/REopt.jl/dev)
+<!-- [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://natlabrockies.github.io/REopt.jl/stable) -->
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://natlabrockies.github.io/REopt.jl/dev)
 
 
 ## Quick Start
@@ -20,4 +20,4 @@ results = run_reopt(m, "pv_storage.json")
 ```
 See the `test/scenarios` directory for examples of `scenario.json`.
 
-For more details, including installation instructions, see the [documentation](https://nrel.github.io/REopt.jl/dev).
+For more details, including installation instructions, see the [documentation](https://natlabrockies.github.io/REopt.jl/dev).

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -652,7 +652,7 @@ function check_api_key()
     if isempty(get(ENV, "NREL_DEVELOPER_API_KEY", ""))
         throw(@error("No NREL Developer API Key provided when trying to call PVWatts or Wind Toolkit.
                     Within your Julia environment, specify ENV['NREL_DEVELOPER_API_KEY']='your API key'
-                    See https://nrel.github.io/REopt.jl/dev/ for more information."))
+                    See https://natlabrockies.github.io/REopt.jl/dev/ for more information."))
     end
 end
 
@@ -660,7 +660,7 @@ function check_api_email()
     if isempty(get(ENV, "NREL_DEVELOPER_EMAIL", ""))
         throw(@error("No NREL Developer API Email provided when trying to call PVWatts or Wind Toolkit.
                     Within your Julia environment, specify ENV['NREL_DEVELOPER_EMAIL']='your contact email'
-                    See https://nrel.github.io/REopt.jl/dev/ for more information."))
+                    See https://natlabrockies.github.io/REopt.jl/dev/ for more information."))
     end
 end
 


### PR DESCRIPTION
I noticed that the Github org name changed and broke links to the documentation. This updates the links throughout this codebase at least. The main site also needs updating.