### PR TITLE
CI: Add the TagBot GitHub Actions workflow file

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,25 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        description: "[DEPRECATED] No longer has any effect"
+        default: "3"
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-slim
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # For commits that modify workflow files: SSH key enables tagging, but
+          # releases require manual creation. For full automation of such commits,
+          # use a PAT with `workflow` scope instead of GITHUB_TOKEN.
+          # See: https://github.com/JuliaRegistries/TagBot#commits-that-modify-workflow-files
+          # ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
+          # changelog_format: github  # 'custom' (default), 'github', or 'conventional'


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
    - Not applicable.
- [x] Docs have been added / updated if applicable
    - Not applicable.
- [x] Any new packages have been added to the [compat] section of Project.toml
    - Not applicable.
- [x] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
    - Not applicable.
- [x] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
    - Not applicable.
- [x] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API
    - Not applicable.

### Replace this with a description of the changes (can just copy from CHANGELOG.md)

This PR adds the TagBot GitHub Actions workflow file. Simply merging this PR is not sufficient to set up TagBot - someone with repository admin permissions also needs to check the GitHub Actions permissions in the repo settings - see https://github.com/JuliaRegistries/TagBot/blob/master/README.md#setup

See https://github.com/JuliaRegistries/General/pull/148202#issuecomment-3901058570 for the motivation for setting up TagBot.

cc: @hdunham