### PR TITLE
Fix lcoe for subhourly loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## develop 
+### Fixed
+- Calculation of offgrid_microgrid_lcoe_dollars_per_kwh for sub-hourly runs.
+
+
 ## v0.58.0
 ### Added
 - New optional attributes for **CHP** object **CHP.serve_absorption_chiller_only**, **CHP.months_serving_absorption_chiller_only**, and **CHP.follow_electrical_load**, which impose constraints on CHP operations if selected.  The default is set to `false` for both attributes.

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -145,7 +145,7 @@ function add_financial_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _
         else
             pwf = p.pwf_owner
         end
-        LoadMet = @expression(m, sum(p.s.electric_load.critical_loads_kw[ts] * m[Symbol("dvOffgridLoadServedFraction"*_n)][ts] for ts in p.time_steps_without_grid ))
+        LoadMet = @expression(m, sum(p.s.electric_load.critical_loads_kw[ts] * m[Symbol("dvOffgridLoadServedFraction"*_n)][ts] for ts in p.time_steps_without_grid )/ p.s.settings.time_steps_per_hour)
         r["offgrid_microgrid_lcoe_dollars_per_kwh"] = round(r["lcc"] / pwf / value(LoadMet), digits=4)
     end
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [ ] Docs have been added / updated if applicable
- [ ] Any new packages have been added to the [compat] section of Project.toml
- [ ] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
- [ ] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
- [ ] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API

### Replace this with a description of the changes (can just copy from CHANGELOG.md)
### Fixed
- Calculation of offgrid_microgrid_lcoe_dollars_per_kwh for sub-hourly runs.
