### PR TITLE
v0.58.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Classify the change according to the following categories:
 ### Fixed
 - Fixed a bug in which the CHP system requires a **DomesticHotWater** load.
 - Fixed a bug in which the storage to steam turbine flow was included in the thermal heating load served.
+- Switched to use maximum value of **dvCoolingProduction** for **ExistingChiller**'s size instead of **dvSize**. This fixed the issue with **ExistingChiller**'s size being applied **max_thermal_factor_on_peak_load** twice in some cases.
 
 ### Changed
 - **HotThermalStorage** and **HighTempThermalStorage** output **storage_to_turbine_series_mmbtu_per_hour** to **storage_to_steamturbine_series_mmbtu_per_hour**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## develop 
+### Fixed
+- Calculation of offgrid_microgrid_lcoe_dollars_per_kwh for sub-hourly runs.
+
+
 ## v0.58.0
 ### Added
 - New optional attributes for **CHP** object **CHP.serve_absorption_chiller_only**, **CHP.months_serving_absorption_chiller_only**, and **CHP.follow_electrical_load**, which impose constraints on CHP operations if selected.  The default is set to `false` for both attributes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,10 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
-## develop 
+## v0.58.1 
 ### Fixed
 - Calculation of offgrid_microgrid_lcoe_dollars_per_kwh for sub-hourly runs.
-
+- Switched to use maximum value of **dvCoolingProduction** for **ExistingChiller**'s size instead of **dvSize**. This fixed the issue with **ExistingChiller**'s size being applied **max_thermal_factor_on_peak_load** twice in some cases.
 
 ## v0.58.0
 ### Added
@@ -42,7 +42,6 @@ Classify the change according to the following categories:
 ### Fixed
 - Fixed a bug in which the CHP system requires a **DomesticHotWater** load.
 - Fixed a bug in which the storage to steam turbine flow was included in the thermal heating load served.
-- Switched to use maximum value of **dvCoolingProduction** for **ExistingChiller**'s size instead of **dvSize**. This fixed the issue with **ExistingChiller**'s size being applied **max_thermal_factor_on_peak_load** twice in some cases.
 
 ### Changed
 - **HotThermalStorage** and **HighTempThermalStorage** output **storage_to_turbine_series_mmbtu_per_hour** to **storage_to_steamturbine_series_mmbtu_per_hour**

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "REopt"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
 authors = ["Nick Laws", "Hallie Dunham <hallie.dunham@nlr.gov>", "Bill Becker <william.becker@nlr.gov>", "Bhavesh Rathod <bhavesh.rathod@nlr.gov>", "Alex Zolan <alexander.zolan@nlr.gov>", "Amanda Farthing <amanda.farthing@nlr.gov>", "Xiangkun Li <xiangkun.li@nlr.gov>", "An Pham <an.pham@nlr.gov>", "Byron Pullutasig <byron.pullatasig@nlr.gov>"]
-version = "0.58.0"
+version = "0.58.1"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/core/existing_chiller.jl
+++ b/src/core/existing_chiller.jl
@@ -5,7 +5,7 @@
     loads_kw_thermal::Vector{<:Real},
     cop::Union{Real, Nothing} = nothing,
     max_thermal_factor_on_peak_load::Real=1.25
-    installed_cost_per_kw::Real = 0.0  # Represents needed CapEx in BAU, assuming net present value basis based on current size; also incurred in Optimal case if still using at all
+    installed_cost_per_ton::Real = 0.0  # Represents needed CapEx in BAU, assuming net present value basis based on current size; also incurred in Optimal case if still using at all
     installed_cost_dollars::Real = 0.0  # Represents needed CapEx in BAU, assuming net present cost basis; also incurred in Optimal case if still using at all
     retire_in_optimal::Bool = false  # Do NOT use in the optimal case (still used in BAU)
 ```

--- a/src/results/existing_chiller.jl
+++ b/src/results/existing_chiller.jl
@@ -11,7 +11,9 @@
 function add_existing_chiller_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
     r = Dict{String, Any}()
 
-	r["size_ton"] = round(value(m[Symbol("dvSize"*_n)]["ExistingChiller"]) * p.s.existing_chiller.max_thermal_factor_on_peak_load / KWH_THERMAL_PER_TONHOUR, digits=3)
+	max_prod_kw = maximum(value.((m[Symbol("dvCoolingProduction"*_n)]["ExistingChiller",:])))
+	size_actual_ton = max_prod_kw / KWH_THERMAL_PER_TONHOUR * p.s.existing_chiller.max_thermal_factor_on_peak_load
+	r["size_ton"] = round(size_actual_ton, digits=3)
 
 	@expression(m, ELECCHLtoTES[ts in p.time_steps],
 		sum(m[:dvProductionToStorage][b,"ExistingChiller",ts] for b in p.s.storage.types.cold)

--- a/src/results/financial.jl
+++ b/src/results/financial.jl
@@ -145,7 +145,7 @@ function add_financial_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _
         else
             pwf = p.pwf_owner
         end
-        LoadMet = @expression(m, sum(p.s.electric_load.critical_loads_kw[ts] * m[Symbol("dvOffgridLoadServedFraction"*_n)][ts] for ts in p.time_steps_without_grid ))
+        LoadMet = @expression(m, sum(p.s.electric_load.critical_loads_kw[ts] * m[Symbol("dvOffgridLoadServedFraction"*_n)][ts] for ts in p.time_steps_without_grid )/ p.s.settings.time_steps_per_hour)
         r["offgrid_microgrid_lcoe_dollars_per_kwh"] = round(r["lcc"] / pwf / value(LoadMet), digits=4)
     end
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [ N/A] Docs have been added / updated if applicable
- [N/A ] Any new packages have been added to the [compat] section of Project.toml
- [x] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
- [ ] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
- [N/A] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API

### Fixed
- Calculation of offgrid_microgrid_lcoe_dollars_per_kwh for sub-hourly runs.
- Switched to use maximum value of **dvCoolingProduction** for **ExistingChiller**'s size instead of **dvSize**. This fixed the issue with **ExistingChiller**'s size being applied **max_thermal_factor_on_peak_load** twice in some cases.
