### PR TITLE
Add Generator O&M Costs by Hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Classify the change according to the following categories:
 
 ## hrly-gen-costs
 ### Added
-- **Generator** **om_cost_per_hr_per_kw_rated**: Generator non-fuel variable operations and maintenance costs in \$/hr/kw_rated
+- **Generator** **om_cost_per_hr_per_kw_rated**: Generator non-fuel variable operations and maintenance costs in \$/hr/kw_rated (default of 0.0)
 
 ## v0.58.1 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## hrly-gen-costs
+### Added
+- **Generator** **om_cost_per_hr_per_kw_rated**: Generator non-fuel variable operations and maintenance costs in \$/hr/kw_rated
+
 ## v0.58.1 
 ### Fixed
 - Calculation of offgrid_microgrid_lcoe_dollars_per_kwh for sub-hourly runs.

--- a/src/constraints/generator_constraints.jl
+++ b/src/constraints/generator_constraints.jl
@@ -67,8 +67,6 @@ function add_generator_hourly_om_charges(m, p)
     dv = "dvOMByHourBySizeGen"
     m[Symbol(dv)] = @variable(m, [p.techs.gen, p.time_steps], base_name=dv, lower_bound=0)
 
-	println(p.s.generator.max_kw)
-
     #Constraint Generator-hourly-om-a: om per hour, per time step >= per_unit_size_cost * size for when on, >= zero when off
 	@constraint(m, GeneratorHourlyOMBySizeA[t in p.techs.gen, ts in p.time_steps],
         p.s.generator.om_cost_per_hr_per_kw_rated * m[Symbol("dvSize")][t] -

--- a/src/constraints/generator_constraints.jl
+++ b/src/constraints/generator_constraints.jl
@@ -67,10 +67,12 @@ function add_generator_hourly_om_charges(m, p)
     dv = "dvOMByHourBySizeGen"
     m[Symbol(dv)] = @variable(m, [p.techs.gen, p.time_steps], base_name=dv, lower_bound=0)
 
+	println(p.s.generator.max_kw)
+
     #Constraint Generator-hourly-om-a: om per hour, per time step >= per_unit_size_cost * size for when on, >= zero when off
 	@constraint(m, GeneratorHourlyOMBySizeA[t in p.techs.gen, ts in p.time_steps],
         p.s.generator.om_cost_per_hr_per_kw_rated * m[Symbol("dvSize")][t] -
-        p.s.generator.max_kw * p.s.generator.om_cost_per_hr_per_kw_rated * (1-m[Symbol("binGenIsOnInTS")][t,ts])
+        (p.s.generator.existing_kw + p.s.generator.max_kw) * p.s.generator.om_cost_per_hr_per_kw_rated * (1-m[Symbol("binGenIsOnInTS")][t,ts])
             <= m[Symbol("dvOMByHourBySizeGen")][t, ts]
     )
 	#Constraint Generator-hourly-om-b: om per hour, per time step <= per_unit_size_cost * size for each hour
@@ -80,7 +82,7 @@ function add_generator_hourly_om_charges(m, p)
     )
 	#Constraint Generator-hourly-om-c: om per hour, per time step <= zero when off, <= per_unit_size_cost*max_size
 	@constraint(m, GeneratorHourlyOMBySizeC[t in p.techs.gen, ts in p.time_steps],
-        p.s.generator.max_kw * p.s.generator.om_cost_per_hr_per_kw_rated * m[Symbol("binGenIsOnInTS")][t,ts]
+        (p.s.generator.existing_kw + p.s.generator.max_kw) * p.s.generator.om_cost_per_hr_per_kw_rated * m[Symbol("binGenIsOnInTS")][t,ts]
             >= m[Symbol("dvOMByHourBySizeGen")][t, ts]
     )
     

--- a/src/constraints/generator_constraints.jl
+++ b/src/constraints/generator_constraints.jl
@@ -36,7 +36,6 @@ function add_binGenIsOnInTS_constraints(m,p)
 	end 
 end
 
-
 function add_gen_can_run_constraints(m,p)
 	if p.s.generator.only_runs_during_grid_outage
 		for ts in p.time_steps_with_grid, t in p.techs.gen
@@ -58,6 +57,38 @@ function add_gen_rated_prod_constraint(m, p)
 	)
 end
 
+"""
+    add_generator_hourly_om_charges(m, p)
+
+- add decision variable "dvOMByHourBySizeGen" for the hourly Generator operations and maintenance costs
+- add the cost to TotalPerUnitHourOMCosts
+"""
+function add_generator_hourly_om_charges(m, p)
+    dv = "dvOMByHourBySizeGen"
+    m[Symbol(dv)] = @variable(m, [p.techs.gen, p.time_steps], base_name=dv, lower_bound=0)
+
+    #Constraint Generator-hourly-om-a: om per hour, per time step >= per_unit_size_cost * size for when on, >= zero when off
+	@constraint(m, GeneratorHourlyOMBySizeA[t in p.techs.gen, ts in p.time_steps],
+        p.s.generator.om_cost_per_hr_per_kw_rated * m[Symbol("dvSize")][t] -
+        p.s.generator.max_kw * p.s.generator.om_cost_per_hr_per_kw_rated * (1-m[Symbol("binGenIsOnInTS")][t,ts])
+            <= m[Symbol("dvOMByHourBySizeGen")][t, ts]
+    )
+	#Constraint Generator-hourly-om-b: om per hour, per time step <= per_unit_size_cost * size for each hour
+	@constraint(m, GeneratorHourlyOMBySizeB[t in p.techs.gen, ts in p.time_steps],
+        p.s.generator.om_cost_per_hr_per_kw_rated * m[Symbol("dvSize")][t]
+            >= m[Symbol("dvOMByHourBySizeGen")][t, ts]
+    )
+	#Constraint Generator-hourly-om-c: om per hour, per time step <= zero when off, <= per_unit_size_cost*max_size
+	@constraint(m, GeneratorHourlyOMBySizeC[t in p.techs.gen, ts in p.time_steps],
+        p.s.generator.max_kw * p.s.generator.om_cost_per_hr_per_kw_rated * m[Symbol("binGenIsOnInTS")][t,ts]
+            >= m[Symbol("dvOMByHourBySizeGen")][t, ts]
+    )
+    
+    m[:TotalHourlyGenOMCosts] = @expression(m, p.third_party_factor * p.pwf_om * 
+    	sum(m[Symbol(dv)][t, ts] * p.hours_per_time_step for t in p.techs.gen, ts in p.time_steps))
+    nothing
+end
+
 
 """
     add_gen_constraints(m, p)
@@ -69,6 +100,11 @@ function add_gen_constraints(m, p)
     add_binGenIsOnInTS_constraints(m,p)
     add_gen_can_run_constraints(m,p)
     add_gen_rated_prod_constraint(m,p)
+
+	m[:TotalHourlyGenOMCosts] = 0
+	if p.s.generator.om_cost_per_hr_per_kw_rated > 1.0E-7
+        add_generator_hourly_om_charges(m, p)
+    end
 
     m[:TotalGenPerUnitProdOMCosts] = @expression(m, p.third_party_factor * p.pwf_om *
         sum(p.s.generator.om_cost_per_kwh * p.hours_per_time_step *

--- a/src/core/generator.jl
+++ b/src/core/generator.jl
@@ -9,7 +9,7 @@
     installed_cost_per_kw::Real = off_grid_flag ? 880 : only_runs_during_grid_outage ? 650.0 : 800.0,
     om_cost_per_kw::Real = off_grid_flag ? 10.0 : 20.0,
     om_cost_per_kwh::Real = 0.0,
-    om_cost_per_hr_per_kw_rated::Float64 = 0.0 # Generator non-fuel variable operations and maintenance costs in \$/hr/kw_rated
+    om_cost_per_hr_per_kw_rated::Float64 = 0.0, # Generator non-fuel variable operations and maintenance costs in \$/hr/kw_rated
     fuel_cost_per_gallon::Real = 2.25,
     electric_efficiency_full_load::Real = 0.322,
     electric_efficiency_half_load::Real = electric_efficiency_full_load,

--- a/src/core/generator.jl
+++ b/src/core/generator.jl
@@ -9,6 +9,7 @@
     installed_cost_per_kw::Real = off_grid_flag ? 880 : only_runs_during_grid_outage ? 650.0 : 800.0,
     om_cost_per_kw::Real = off_grid_flag ? 10.0 : 20.0,
     om_cost_per_kwh::Real = 0.0,
+    om_cost_per_hr_per_kw_rated::Float64 = 0.0 # Generator non-fuel variable operations and maintenance costs in \$/hr/kw_rated
     fuel_cost_per_gallon::Real = 2.25,
     electric_efficiency_full_load::Real = 0.322,
     electric_efficiency_half_load::Real = electric_efficiency_full_load,
@@ -57,6 +58,7 @@ struct Generator <: AbstractGenerator
     installed_cost_per_kw
     om_cost_per_kw
     om_cost_per_kwh
+    om_cost_per_hr_per_kw_rated
     fuel_cost_per_gallon
     electric_efficiency_full_load
     electric_efficiency_half_load
@@ -104,6 +106,7 @@ struct Generator <: AbstractGenerator
         installed_cost_per_kw::Real = off_grid_flag ? 880 : only_runs_during_grid_outage ? 650.0 : 800.0,
         om_cost_per_kw::Real= off_grid_flag ? 10.0 : 20.0,
         om_cost_per_kwh::Real = 0.0,
+        om_cost_per_hr_per_kw_rated::Float64 = 0.0, # Generator non-fuel variable operations and maintenance costs in \$/hr/kw_rated
         fuel_cost_per_gallon::Real = 2.25,
         electric_efficiency_full_load::Real = 0.322,
         electric_efficiency_half_load::Real = electric_efficiency_full_load,
@@ -152,6 +155,7 @@ struct Generator <: AbstractGenerator
             installed_cost_per_kw,
             om_cost_per_kw,
             om_cost_per_kwh,
+            om_cost_per_hr_per_kw_rated,
             fuel_cost_per_gallon,
             electric_efficiency_full_load,
             electric_efficiency_half_load,

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -244,7 +244,6 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 
     m[:TotalTechCapCosts] = 0.0
     m[:TotalPerUnitProdOMCosts] = 0.0
-	m[:TotalRuntimeOMCosts] = 0.0
     m[:TotalPerUnitHourOMCosts] = 0.0
     m[:TotalFuelCosts] = 0.0
     m[:TotalProductionIncentive] = 0

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -244,6 +244,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 
     m[:TotalTechCapCosts] = 0.0
     m[:TotalPerUnitProdOMCosts] = 0.0
+	m[:TotalRuntimeOMCosts] = 0.0
     m[:TotalPerUnitHourOMCosts] = 0.0
     m[:TotalFuelCosts] = 0.0
     m[:TotalProductionIncentive] = 0
@@ -274,6 +275,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
             add_gen_constraints(m, p)
             m[:TotalPerUnitProdOMCosts] += m[:TotalGenPerUnitProdOMCosts]
             m[:TotalFuelCosts] += m[:TotalGenFuelCosts]
+			m[:TotalPerUnitHourOMCosts] += m[:TotalHourlyGenOMCosts]
         end
 
         if !isempty(p.techs.chp)

--- a/src/mpc/model.jl
+++ b/src/mpc/model.jl
@@ -153,6 +153,7 @@ function build_mpc!(m::JuMP.AbstractModel, p::MPCInputs)
 	
     m[:TotalFuelCosts] = 0.0
     m[:TotalPerUnitProdOMCosts] = 0.0
+	m[:TotalPerUnitHourOMCosts] = 0.0
 
     if !isempty(p.techs.gen)
         add_gen_constraints(m, p)
@@ -164,6 +165,7 @@ function build_mpc!(m::JuMP.AbstractModel, p::MPCInputs)
             sum(m[:dvFuelUsage][t,ts] * p.s.generator.fuel_cost_per_gallon for t in p.techs.gen, ts in p.time_steps)
         )
         m[:TotalFuelCosts] += m[:TotalGenFuelCosts]
+		m[:TotalPerUnitHourOMCosts] += m[:TotalHourlyGenOMCosts]
 	end
 
 	add_elec_utility_expressions(m, p)
@@ -203,7 +205,7 @@ function build_mpc!(m::JuMP.AbstractModel, p::MPCInputs)
 	@expression(m, Costs,
 
 		# Variable O&M
-		m[:TotalPerUnitProdOMCosts] +
+		m[:TotalPerUnitProdOMCosts] + m[:TotalPerUnitHourOMCosts] +
 
 		# Total Generator Fuel Costs
         m[:TotalFuelCosts] +

--- a/src/mpc/structs.jl
+++ b/src/mpc/structs.jl
@@ -261,6 +261,7 @@ function MPCGenerator(;
     only_runs_during_grid_outage::Bool = true,
     sells_energy_back_to_grid::Bool = false,
     om_cost_per_kwh::Real=0.0,
+    om_cost_per_hr_per_kw_rated::Real=0.0,
     )
 ```
 """
@@ -276,6 +277,7 @@ struct MPCGenerator <: AbstractGenerator
     only_runs_during_grid_outage
     sells_energy_back_to_grid
     om_cost_per_kwh
+    om_cost_per_hr_per_kw_rated
 
     function MPCGenerator(;
         size_kw::Real,
@@ -288,6 +290,7 @@ struct MPCGenerator <: AbstractGenerator
         only_runs_during_grid_outage::Bool = true,
         sells_energy_back_to_grid::Bool = false,
         om_cost_per_kwh::Real=0.0,
+        om_cost_per_hr_per_kw_rated::Real=0.0,
         )
 
         max_kw = size_kw
@@ -304,6 +307,7 @@ struct MPCGenerator <: AbstractGenerator
             only_runs_during_grid_outage,
             sells_energy_back_to_grid,
             om_cost_per_kwh,
+            om_cost_per_hr_per_kw_rated
         )
     end
 end

--- a/src/results/generator.jl
+++ b/src/results/generator.jl
@@ -4,8 +4,8 @@
 - `size_kw` Optimal generator capacity
 - `lifecycle_fixed_om_cost_after_tax` Lifecycle fixed operations and maintenance cost in present value, after tax
 - `year_one_fixed_om_cost_before_tax` fixed operations and maintenance cost over the first year, before considering tax benefits
-- `lifecycle_variable_om_cost_after_tax` Lifecycle variable operations and maintenance cost in present value, after tax
-- `year_one_variable_om_cost_before_tax` variable operations and maintenance cost over the first year, before considering tax benefits
+- `lifecycle_variable_om_cost_after_tax` Lifecycle variable operations and maintenance cost in present value, after tax. Includes om_cost_per_kwh and om_cost_per_hr_per_kw_rated
+- `year_one_variable_om_cost_before_tax` variable operations and maintenance cost over the first year, before considering tax benefits. Includes om_cost_per_kwh and om_cost_per_hr_per_kw_rated
 - `lifecycle_fuel_cost_after_tax` Lifecycle fuel cost in present value, after tax
 - `year_one_fuel_cost_before_tax` Fuel cost over the first year, before considering tax benefits. Does not include fuel use during outages if using multiple outage modeling.
 - `year_one_fuel_cost_after_tax` Fuel cost over the first year, after considering tax benefits. Does not include fuel use during outages if using multiple outage modeling.
@@ -28,17 +28,13 @@ function add_generator_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _
 
 	GenPerUnitSizeOMCosts = @expression(m, p.third_party_factor * p.pwf_om * sum(m[:dvSize][t] * p.om_cost_per_kw[t] for t in p.techs.gen))
 
-	GenPerUnitProdOMCosts = @expression(m, p.third_party_factor * p.pwf_om * p.hours_per_time_step *
-		sum(m[:dvRatedProduction][t, ts] * p.production_factor[t, ts] * p.s.generator.om_cost_per_kwh
-			for t in p.techs.gen, ts in p.time_steps)
-	)
 	r["size_kw"] = round(value(sum(m[:dvSize][t] for t in p.techs.gen)), digits=2)
 	r["lifecycle_fixed_om_cost_after_tax"] = round(value(GenPerUnitSizeOMCosts) * (1 - p.s.financial.owner_tax_rate_fraction), digits=0)
-	r["lifecycle_variable_om_cost_after_tax"] = round(value(m[:TotalPerUnitProdOMCosts]) * (1 - p.s.financial.owner_tax_rate_fraction), digits=0)
+	r["lifecycle_variable_om_cost_after_tax"] = round((value(m[:TotalGenPerUnitProdOMCosts]) + value(m[:TotalHourlyGenOMCosts])) * (1 - p.s.financial.owner_tax_rate_fraction), digits=0)
 	r["lifecycle_fuel_cost_after_tax"] = round(value(m[:TotalGenFuelCosts]) * (1 - p.s.financial.offtaker_tax_rate_fraction), digits=2)
 	r["year_one_fuel_cost_before_tax"] = round(value(m[:TotalGenFuelCosts]) / p.pwf_fuel["Generator"], digits=2)
 	r["year_one_fuel_cost_after_tax"] = r["year_one_fuel_cost_before_tax"] * (1 - p.s.financial.offtaker_tax_rate_fraction)
-	r["year_one_variable_om_cost_before_tax"] = round(value(GenPerUnitProdOMCosts) / (p.pwf_om * p.third_party_factor), digits=0)
+	r["year_one_variable_om_cost_before_tax"] = round(value(m[:TotalGenPerUnitProdOMCosts] + m[:TotalHourlyGenOMCosts]) / (p.pwf_om * p.third_party_factor), digits=0)
 	r["year_one_fixed_om_cost_before_tax"] = round(value(GenPerUnitSizeOMCosts) / (p.pwf_om * p.third_party_factor), digits=0)
 
 	if !isempty(p.s.storage.types.elec)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2500,6 +2500,7 @@ else  # run HiGHS tests
             post["PV"]["max_kw"] = 0.0
             post["ElectricStorage"]["max_kw"] = 0.0
             post["Generator"]["min_turn_down_fraction"] = 0.0
+            post["Generator"]["om_cost_per_hr_per_kw_rated"] = 2.0
             finalize(backend(m))
             empty!(m)
             GC.gc()            
@@ -2518,7 +2519,9 @@ else  # run HiGHS tests
             @test r["Financial"]["lifecycle_capital_costs"] ≈ 100*(700+324.235442*(1-0.26)) + other_offgrid_capex_after_tax atol=0.1 # replacement in yr 10 is considered tax deductible
             @test r["Financial"]["initial_capital_costs_after_incentives"] ≈ 700*100 + other_offgrid_capex_after_tax atol=0.1
             @test r["Financial"]["replacements_future_cost_after_tax"] ≈ 700*100
-            @test r["Financial"]["replacements_present_cost_after_tax"] ≈ 100*(324.235442*(1-0.26)) atol=0.1 
+            @test r["Financial"]["replacements_present_cost_after_tax"] ≈ 100*(324.235442*(1-0.26)) atol=0.1
+            generator_hours_runtime = sum(x -> x > 0, r["Generator"]["electric_to_load_series_kw"]) + sum(x -> x > 0, r["Generator"]["electric_to_storage_series_kw"])
+            @test r["Generator"]["year_one_variable_om_cost_before_tax"] ≈ generator_hours_runtime * r["Generator"]["size_kw"] * post["Generator"]["om_cost_per_hr_per_kw_rated"] atol=0.1
 
             ## Scenario 3: Fixed Generator that can meet load, but cannot meet load operating reserve requirement
             ## This test ensures the load operating reserve requirement is being enforced


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [ N/A] Docs have been added / updated if applicable
- [ N/A] Any new packages have been added to the [compat] section of Project.toml
- [N/A ] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
- [x] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
- [ not adding to API] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API

### Added
- **Generator** **om_cost_per_hr_per_kw_rated**: Generator non-fuel variable operations and maintenance costs in \$/hr/kw_rated. This value defaults to 0. 