### PR TITLE
Bug fixes in TES-to-Turbine results and CHP heuristic input processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## fix-tes-results-fields
+### Changed
+- Refactored some results expressions so that `value.` isn't called within them.
+
+### Fixed
+- Fixed an error creating results for flows from hot TES to the steam turbine.
+- Fixed an bug preventing `include_cooling_in_chp_size` from being included in CHP inputs.
+
 ## v0.58.1 
 ### Fixed
 - Calculation of offgrid_microgrid_lcoe_dollars_per_kwh for sub-hourly runs.

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -43,7 +43,6 @@ conflict_res_min_allowable_fraction_of_max = 0.25
     serve_absorption_chiller_only::Bool = false # If CHP produced heat either serves absorption chiller or sends it to waste; only applies to the months specified in months_serving_absorption_chiller_only if true
     months_serving_absorption_chiller_only::AbstractVector{Int64} = Int64[] # months in which CHP only sevres the absorption chiller, with 1=January and 12=December; only applied when serve_absorption_chiller_only = true
     follow_electrical_load::Bool = false # If CHP follows the electrical load by running at capacity or meeting the load only.
-    include_cooling_in_chp_size::Bool = false # If true, includes cooling load (via absorption chiller) in the heuristic CHP sizing calculation along with heating loads. Defaults to true when AbsorptionChiller is present with CHP. Requires CoolingLoad to be specified.
 
     macrs_option_years::Int = 5 # Notes: this value cannot be 0 if aiming to apply 100% bonus depreciation; default may change if Site.sector is not "commercial/industrial"
     macrs_bonus_fraction::Float64 = 1.0 #Note: default may change if Site.sector is not "commercial/industrial"

--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -473,7 +473,11 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
         avg_cooling_load_kw = nothing
         absorption_chiller_cop = nothing
         # User can override by explicitly setting include_cooling_in_chp_size = false
-        include_cooling_in_size = get(d["CHP"], "include_cooling_in_chp_size", haskey(d, "AbsorptionChiller"))
+        if "include_cooling_in_chp_size" in keys(d["CHP"])
+            include_cooling_in_size = pop!(d["CHP"], "include_cooling_in_chp_size")
+        else
+            include_cooling_in_size = haskey(d, "AbsorptionChiller")
+        end
         
         if max_cooling_demand_kw > 0 && include_cooling_in_size
             # Use already-processed cooling_load object
@@ -498,7 +502,7 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
                     sector = site.sector,
                     federal_procurement_type = site.federal_procurement_type)
         else # Only if modeling CHP without heating_load and existing_boiler (for prime generator, electric-only)
-            chp = CHP(d["CHP"],
+            chp = CHP(d["CHP"];
                     electric_load_series_kw = electric_load.loads_kw,
                     avg_cooling_load_kw = avg_cooling_load_kw,
                     absorption_chiller_cop = absorption_chiller_cop,

--- a/src/results/boiler.jl
+++ b/src/results/boiler.jl
@@ -55,8 +55,8 @@ function add_boiler_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="
     r["thermal_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(NewBoilerToSteamTurbine), digits=3)
 
     if "AbsorptionChiller" in p.techs.cooling
-		@expression(m, NewBoilertoAbsorptionChillerKW[ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller]["Boiler",q,ts] for q in p.heating_loads)))
-		@expression(m, NewBoilertoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller]["Boiler",q,ts])))
+		@expression(m, NewBoilertoAbsorptionChillerKW[ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller]["Boiler",q,ts] for q in p.heating_loads))
+		@expression(m, NewBoilertoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller]["Boiler",q,ts]))
 	else
 		@expression(m, NewBoilertoAbsorptionChillerKW[ts in p.time_steps], 0.0)
 		@expression(m, NewBoilertoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], 0.0)

--- a/src/results/chp.jl
+++ b/src/results/chp.jl
@@ -100,8 +100,8 @@ function add_chp_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
     end	
     r["thermal_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(CHPToSteamTurbineKW) / KWH_PER_MMBTU, digits=5)
 	if "AbsorptionChiller" in p.techs.cooling
-		@expression(m, CHPtoAbsorptionChillerKW[ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller][t,q,ts] for t in p.techs.chp, q in p.heating_loads)))
-		@expression(m, CHPtoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller][t,q,ts] for t in p.techs.chp)))
+		@expression(m, CHPtoAbsorptionChillerKW[ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller][t,q,ts] for t in p.techs.chp, q in p.heating_loads))
+		@expression(m, CHPtoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller][t,q,ts] for t in p.techs.chp))
 	else
 		@expression(m, CHPtoAbsorptionChillerKW[ts in p.time_steps], 0.0)
 		@expression(m, CHPtoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], 0.0)

--- a/src/results/cst.jl
+++ b/src/results/cst.jl
@@ -71,8 +71,8 @@ function add_concentrating_solar_results(m::JuMP.AbstractModel, p::REoptInputs, 
     r["thermal_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(CSTToSteamTurbine) / KWH_PER_MMBTU, digits=3)
 
     if "AbsorptionChiller" in p.techs.cooling
-		@expression(m, CSTtoAbsorptionChillerKW[ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller]["CST",q,ts] for q in p.heating_loads)))
-		@expression(m, CSTtoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller]["CST",q,ts])))
+		@expression(m, CSTtoAbsorptionChillerKW[ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller]["CST",q,ts] for q in p.heating_loads))
+		@expression(m, CSTtoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller]["CST",q,ts]))
 	else
 		@expression(m, CSTtoAbsorptionChillerKW[ts in p.time_steps], 0.0)
 		@expression(m, CSTtoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], 0.0)

--- a/src/results/electric_heater.jl
+++ b/src/results/electric_heater.jl
@@ -68,8 +68,8 @@ function add_electric_heater_results(m::JuMP.AbstractModel, p::REoptInputs, d::D
     r["thermal_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(ElectricHeaterToSteamTurbine) / KWH_PER_MMBTU, digits=3)
 
     if "AbsorptionChiller" in p.techs.cooling
-		@expression(m, ElectricHeatertoAbsorptionChillerKW[ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller]["ElectricHeater",q,ts] for q in p.heating_loads)))
-		@expression(m, ElectricHeatertoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller]["ElectricHeater",q,ts])))
+		@expression(m, ElectricHeatertoAbsorptionChillerKW[ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller]["ElectricHeater",q,ts] for q in p.heating_loads))
+		@expression(m, ElectricHeatertoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller]["ElectricHeater",q,ts]))
 	else
 		@expression(m, ElectricHeatertoAbsorptionChillerKW[ts in p.time_steps], 0.0)
 		@expression(m, ElectricHeatertoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], 0.0)

--- a/src/results/existing_boiler.jl
+++ b/src/results/existing_boiler.jl
@@ -58,8 +58,8 @@ function add_existing_boiler_results(m::JuMP.AbstractModel, p::REoptInputs, d::D
     r["thermal_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(BoilerToSteamTurbineKW) ./ KWH_PER_MMBTU, digits=5)
 
     if "AbsorptionChiller" in p.techs.cooling
-		@expression(m, BoilertoAbsorptionChillerKW[ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller]["ExistingBoiler",q,ts] for q in p.heating_loads)))
-		@expression(m, BoilertoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller]["ExistingBoiler",q,ts])))
+		@expression(m, BoilertoAbsorptionChillerKW[ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller]["ExistingBoiler",q,ts] for q in p.heating_loads))
+		@expression(m, BoilertoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller]["ExistingBoiler",q,ts]))
 	else
 		@expression(m, BoilertoAbsorptionChillerKW[ts in p.time_steps], 0.0)
 		@expression(m, BoilertoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], 0.0)

--- a/src/results/steam_turbine.jl
+++ b/src/results/steam_turbine.jl
@@ -91,8 +91,8 @@ function add_steam_turbine_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dic
 	r["thermal_to_high_temp_thermal_storage_series_mmbtu_per_hour"] = round.(value.(m[:SteamTurbineToHotSensibleTESKW]) ./ KWH_PER_MMBTU, digits=5)
 	
 	if "AbsorptionChiller" in p.techs.cooling
-		@expression(m, SteamTurbinetoAbsorptionChillerKW[ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller][t,q,ts] for t in p.techs.steam_turbine, q in p.heating_loads)))
-		@expression(m, SteamTurbinetoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(value.(m[:dvHeatToAbsorptionChiller][t,q,ts] for t in p.techs.steam_turbine)))
+		@expression(m, SteamTurbinetoAbsorptionChillerKW[ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller][t,q,ts] for t in p.techs.steam_turbine, q in p.heating_loads))
+		@expression(m, SteamTurbinetoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], sum(m[:dvHeatToAbsorptionChiller][t,q,ts] for t in p.techs.steam_turbine))
 	else
 		@expression(m, SteamTurbinetoAbsorptionChillerKW[ts in p.time_steps], 0.0)
 		@expression(m, SteamTurbinetoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], 0.0)

--- a/src/results/thermal_storage.jl
+++ b/src/results/thermal_storage.jl
@@ -43,24 +43,20 @@ function add_hot_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict,
         r["storage_to_absorption_chiller_series_mmbtu_per_hour"] = round.(value.(HotTEStoAbsorptionChillerKW) / KWH_PER_MMBTU, digits=7)
 
         if p.s.storage.attr[b].can_supply_steam_turbine && ("SteamTurbine" in p.techs.all)
-            storage_to_turbine = (sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,q,ts] for q in p.heating_loads) for ts in p.time_steps)
-            storage_to_turbine_sh = (sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,"SpaceHeating",ts]) for ts in p.time_steps)
-            storage_to_turbine_dhw = (sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,"DomesticHotWater",ts]) for ts in p.time_steps)
-            storage_to_turbine_ph = (sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,"ProcessHeat",ts]) for ts in p.time_steps)
-            r["storage_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(storage_to_turbine) / KWH_PER_MMBTU, digits=7)
-            r["storage_to_load_series_mmbtu_per_hour"] = round.(value.(discharge .- storage_to_turbine .- HotTEStoAbsorptionChillerKW) / KWH_PER_MMBTU, digits=7)
+            @expression(m, HotTEStoTurbineKW[ts in p.time_steps], sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,q,ts] for q in p.heating_loads))
+            @expression(m, HotTEStoTurbineByQualityKW[q in p.heating_loads, ts in p.time_steps], m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,q,ts])
+            r["storage_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(HotTEStoTurbineKW) / KWH_PER_MMBTU, digits=7)
+            r["storage_to_load_series_mmbtu_per_hour"] = round.(value.(discharge .- HotTEStoTurbineKW .- HotTEStoAbsorptionChillerKW) / KWH_PER_MMBTU, digits=7)
         else
-            storage_to_turbine = zeros(length(p.time_steps))
-            storage_to_turbine_sh = zeros(length(p.time_steps))
-            storage_to_turbine_dhw = zeros(length(p.time_steps))
-            storage_to_turbine_ph = zeros(length(p.time_steps))
+            @expression(m, HotTEStoTurbineKW[ts in p.time_steps], 0.0)
+            @expression(m, HotTEStoTurbineByQualityKW[q in p.heating_loads, ts in p.time_steps], 0.0)
             r["storage_to_load_series_mmbtu_per_hour"] = round.(value.(discharge .- HotTEStoAbsorptionChillerKW) / KWH_PER_MMBTU, digits=7)
             r["storage_to_steamturbine_series_mmbtu_per_hour"] = zeros(length(p.time_steps))
         end
 
         if "SpaceHeating" in p.heating_loads && p.s.storage.attr[b].can_serve_space_heating
             @expression(m, HotTESToSpaceHeatingKW[ts in p.time_steps], 
-                m[Symbol("dvHeatFromStorage"*_n)][b,"SpaceHeating",ts] - storage_to_turbine_sh[ts] - HotTEStoAbsorptionChillerByQualityKW["SpaceHeating",ts]
+                m[Symbol("dvHeatFromStorage"*_n)][b,"SpaceHeating",ts] - HotTEStoTurbineByQualityKW["SpaceHeating",ts] - HotTEStoAbsorptionChillerByQualityKW["SpaceHeating",ts]
             )
         else
             @expression(m, HotTESToSpaceHeatingKW[ts in p.time_steps], 0.0)
@@ -69,7 +65,7 @@ function add_hot_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict,
 
         if "DomesticHotWater" in p.heating_loads && p.s.storage.attr[b].can_serve_dhw
             @expression(m, HotTESToDHWKW[ts in p.time_steps], 
-                m[Symbol("dvHeatFromStorage"*_n)][b,"DomesticHotWater",ts] - storage_to_turbine_dhw[ts] - HotTEStoAbsorptionChillerByQualityKW["DomesticHotWater",ts]
+                m[Symbol("dvHeatFromStorage"*_n)][b,"DomesticHotWater",ts] - HotTEStoTurbineByQualityKW["DomesticHotWater",ts] - HotTEStoAbsorptionChillerByQualityKW["DomesticHotWater",ts]
             )
         else
             @expression(m, HotTESToDHWKW[ts in p.time_steps], 0.0)
@@ -78,7 +74,7 @@ function add_hot_storage_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict,
 
         if "ProcessHeat" in p.heating_loads && p.s.storage.attr[b].can_serve_process_heat
             @expression(m, HotTESToProcessHeatKW[ts in p.time_steps], 
-                m[Symbol("dvHeatFromStorage"*_n)][b,"ProcessHeat",ts] - storage_to_turbine_ph[ts] - HotTEStoAbsorptionChillerByQualityKW["ProcessHeat",ts]
+                m[Symbol("dvHeatFromStorage"*_n)][b,"ProcessHeat",ts] - HotTEStoTurbineByQualityKW["ProcessHeat",ts] - HotTEStoAbsorptionChillerByQualityKW["ProcessHeat",ts]
             )
         else
             @expression(m, HotTESToProcessHeatKW[ts in p.time_steps], 0.0)
@@ -197,8 +193,8 @@ function add_high_temp_thermal_storage_results(m::JuMP.AbstractModel, p::REoptIn
 
         discharge = (sum(m[Symbol("dvHeatFromStorage"*_n)][b,q,ts] for q in p.heating_loads) for ts in p.time_steps)
         if "AbsorptionChiller" in p.techs.cooling
-            @expression(m, HighTempTEStoAbsorptionChillerKW[ts in p.time_steps], sum(value.(m[:dvHeatFromStorageToAbsorptionChiller][b,q,ts] for q in p.heating_loads)))
-            @expression(m, HighTempTEStoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], value(m[:dvHeatFromStorageToAbsorptionChiller][b,q,ts]))
+            @expression(m, HighTempTEStoAbsorptionChillerKW[ts in p.time_steps], sum(m[:dvHeatFromStorageToAbsorptionChiller][b,q,ts] for q in p.heating_loads))
+            @expression(m, HighTempTEStoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], m[:dvHeatFromStorageToAbsorptionChiller][b,q,ts])
         else
             @expression(m, HighTempTEStoAbsorptionChillerKW[ts in p.time_steps], 0.0)
             @expression(m, HighTempTEStoAbsorptionChillerByQualityKW[q in p.heating_loads, ts in p.time_steps], 0.0)
@@ -206,24 +202,20 @@ function add_high_temp_thermal_storage_results(m::JuMP.AbstractModel, p::REoptIn
         r["storage_to_absorption_chiller_series_mmbtu_per_hour"] = round.(value.(HighTempTEStoAbsorptionChillerKW) / KWH_PER_MMBTU, digits=7)
         
         if p.s.storage.attr[b].can_supply_steam_turbine && ("SteamTurbine" in p.techs.all)
-            storage_to_turbine = (sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,q,ts] for q in p.heating_loads) for ts in p.time_steps)
-            storage_to_turbine_sh = (sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,"SpaceHeating",ts]) for ts in p.time_steps)
-            storage_to_turbine_dhw = (sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,"DomesticHotWater",ts]) for ts in p.time_steps)
-            storage_to_turbine_ph = (sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,"ProcessHeat",ts]) for ts in p.time_steps)
-            r["storage_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(storage_to_turbine) / KWH_PER_MMBTU, digits=7)
-            r["storage_to_load_series_mmbtu_per_hour"] = round.(value.(discharge .- storage_to_turbine .- HighTempTEStoAbsorptionChillerKW) / KWH_PER_MMBTU, digits=7)
+            @expression(m, HighTempTEStoTurbineKW[ts in p.time_steps], sum(m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,q,ts] for q in p.heating_loads))
+            @expression(m, HighTempTEStoTurbineByQualityKW[q in p.heating_loads, ts in p.time_steps], m[Symbol("dvHeatFromStorageToTurbine"*_n)][b,q,ts])
+            r["storage_to_steamturbine_series_mmbtu_per_hour"] = round.(value.(HighTempTEStoTurbineKW) / KWH_PER_MMBTU, digits=7)
+            r["storage_to_load_series_mmbtu_per_hour"] = round.(value.(discharge .- HighTempTEStoTurbineKW .- HighTempTEStoAbsorptionChillerKW) / KWH_PER_MMBTU, digits=7)
         else
-            storage_to_turbine = zeros(length(p.time_steps))
-            storage_to_turbine_sh = zeros(length(p.time_steps))
-            storage_to_turbine_dhw = zeros(length(p.time_steps))
-            storage_to_turbine_ph = zeros(length(p.time_steps))
+            @expression(m, HighTempTEStoTurbineKW[ts in p.time_steps], 0.0)
+            @expression(m, HighTempTEStoTurbineByQualityKW[q in p.heating_loads, ts in p.time_steps], 0.0)
             r["storage_to_load_series_mmbtu_per_hour"] = round.(value.(discharge .- HighTempTEStoAbsorptionChillerKW) / KWH_PER_MMBTU, digits=7)
             r["storage_to_steamturbine_series_mmbtu_per_hour"] = zeros(length(p.time_steps))
         end
 
         if "SpaceHeating" in p.heating_loads && p.s.storage.attr[b].can_serve_space_heating
             @expression(m, HighTempTESToSpaceHeatingKW[ts in p.time_steps], 
-                m[Symbol("dvHeatFromStorage"*_n)][b,"SpaceHeating",ts] - storage_to_turbine_sh[ts] - HighTempTEStoAbsorptionChillerByQualityKW["SpaceHeating",ts]
+                m[Symbol("dvHeatFromStorage"*_n)][b,"SpaceHeating",ts] - HighTempTEStoTurbineByQualityKW["SpaceHeating",ts] - HighTempTEStoAbsorptionChillerByQualityKW["SpaceHeating",ts]
             )
         else
             @expression(m, HighTempTESToSpaceHeatingKW[ts in p.time_steps], 0.0)
@@ -232,7 +224,7 @@ function add_high_temp_thermal_storage_results(m::JuMP.AbstractModel, p::REoptIn
 
         if "DomesticHotWater" in p.heating_loads && p.s.storage.attr[b].can_serve_dhw
             @expression(m, HighTempTESToDHWKW[ts in p.time_steps], 
-                m[Symbol("dvHeatFromStorage"*_n)][b,"DomesticHotWater",ts] - storage_to_turbine_dhw[ts] - HighTempTEStoAbsorptionChillerByQualityKW["DomesticHotWater",ts]
+                m[Symbol("dvHeatFromStorage"*_n)][b,"DomesticHotWater",ts] - HighTempTEStoTurbineByQualityKW["DomesticHotWater",ts] - HighTempTEStoAbsorptionChillerByQualityKW["DomesticHotWater",ts]
             )
         else
             @expression(m, HighTempTESToDHWKW[ts in p.time_steps], 0.0)
@@ -241,7 +233,7 @@ function add_high_temp_thermal_storage_results(m::JuMP.AbstractModel, p::REoptIn
 
         if "ProcessHeat" in p.heating_loads && p.s.storage.attr[b].can_serve_process_heat
             @expression(m, HighTempTESToProcessHeatKW[ts in p.time_steps], 
-                m[Symbol("dvHeatFromStorage"*_n)][b,"ProcessHeat",ts] - storage_to_turbine_ph[ts] - HighTempTEStoAbsorptionChillerByQualityKW["ProcessHeat",ts]
+                m[Symbol("dvHeatFromStorage"*_n)][b,"ProcessHeat",ts] - HighTempTEStoTurbineByQualityKW["ProcessHeat",ts] - HighTempTEStoAbsorptionChillerByQualityKW["ProcessHeat",ts]
             )
         else
             @expression(m, HighTempTESToProcessHeatKW[ts in p.time_steps], 0.0)

--- a/test/scenarios/chp_waste.json
+++ b/test/scenarios/chp_waste.json
@@ -86,6 +86,7 @@
         "macrs_option_years": 5,
         "macrs_bonus_fraction": 0.6,
         "can_wholesale": false,
+        "include_cooling_in_chp_size": false,
         "fuel_cost_per_mmbtu": [
             6.26,
             8.36,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Docs have been added / updated if applicable
- [x] Any new packages have been added to the [compat] section of Project.toml
- [x] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
- [x] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
- [x] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API

### Fixed
- Fixed an error creating results for flows from hot TES to the steam turbine.
- Fixed an bug preventing `include_cooling_in_chp_size` from being included in CHP inputs.

### Changed
- Refactored some results expressions so that `value.` isn't called within them.
