### PR TITLE
Update `get_steam_turbine_defaults_size_class()` for added size classes

### DIFF
--- a/src/core/steam_turbine.jl
+++ b/src/core/steam_turbine.jl
@@ -223,13 +223,13 @@ Depending on the set of inputs, different sets of outputs are determine in addit
 """
 function get_steam_turbine_defaults_size_class(;avg_boiler_fuel_load_mmbtu_per_hour::Union{Float64, Nothing}=nothing, size_class::Union{Int64, Nothing}=nothing)
     defaults = JSON.parsefile(joinpath(dirname(@__FILE__), "..", "..", "data", "steam_turbine", "steam_turbine_default_data.json"))
-    class_bounds = [(0.0, 25000.0), (0, 1000.0), (1000.0, 5000.0), (5000.0, 25000.0)]
+    class_bounds = [(0.0, 40000.0), (0, 400.0), (400.0, 1000.0), (1000.0, 5000.0), (5000.0, 15000.0), (15000.0, 40000.0)]
     n_classes = length(class_bounds)
     steam_turbine_electric_efficiency = 0.07 # Typical, steam_turbine_kwe / boiler_fuel_kwt
     st_elec_size_heuristic_kw = nothing
     if !isnothing(size_class)
         if size_class < 0 || size_class > (n_classes-1)
-            throw(@error("Invalid size_class $size_class given for steam_turbine, must be in [0,1,2,3]"))
+            throw(@error("Invalid size_class $size_class given for steam_turbine, must be in [0,1,2,3,4,5]"))
         end
         if !isnothing(avg_boiler_fuel_load_mmbtu_per_hour)
             thermal_power_in_kw = avg_boiler_fuel_load_mmbtu_per_hour * KWH_PER_MMBTU


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Docs have been added / updated if applicable
- [x] Any new packages have been added to the [compat] section of Project.toml
- [ ] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
- [ ] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
- [ ] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API

### Replace this with a description of the changes (can just copy from CHANGELOG.md)
Existing CHANGELOG.md description covers changes introduced in this PR.
