### PR TITLE
Fixes for CHP-to-AbsChl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## fix-chp-to-abschl
+### Fixed
+- `constraints/thermal_tech_constraints.jl`: In `add_heating_tech_constraints`, updated waste heat constraints to include **dvHeatToAbsorptionChiller** in the total heat output, so that `dvProductionToWaste + dvHeatToAbsorptionChiller <= dvHeatingProduction`. Previously, heat dispatched to the absorption chiller was unconstrained by total production.
+- `core/techs.jl`: In `Techs(s::Scenario)`, prevented zeroing out `can_serve_dhw`, `can_serve_space_heating`, and `can_serve_process_heat` technology lists when the corresponding direct load is zero, if an **AbsorptionChiller** is using that heating quality as its heat source. This ensures heating technologies remain available to supply heat to the absorption chiller even when no direct heating load exists.
+
 ## v0.59.0
 ### Added
 - Added two new size classes for **SteamTurbine** tech with new tech size ranges.

--- a/src/constraints/thermal_tech_constraints.jl
+++ b/src/constraints/thermal_tech_constraints.jl
@@ -44,7 +44,7 @@ function add_heating_tech_constraints(m, p; _n="")
             )
             if !isempty(setdiff(union(p.techs.heating, p.techs.chp),p.techs.can_supply_steam_turbine))
                 @constraint(m, [t in setdiff(union(p.techs.heating,p.techs.chp),p.techs.can_supply_steam_turbine), q in p.heating_loads, ts in p.time_steps],
-                    m[Symbol("dvProductionToWaste"*_n)][t,q,ts]  <=  m[Symbol("dvHeatingProduction"*_n)][t,q,ts]
+                    m[Symbol("dvProductionToWaste"*_n)][t,q,ts] + m[Symbol("dvHeatToAbsorptionChiller"*_n)][t,q,ts]  <=  m[Symbol("dvHeatingProduction"*_n)][t,q,ts]
                 )
             end
         end
@@ -56,7 +56,7 @@ function add_heating_tech_constraints(m, p; _n="")
             )
         else
             @constraint(m, [t in union(p.techs.heating, p.techs.chp), q in p.heating_loads, ts in p.time_steps],
-                m[Symbol("dvProductionToWaste"*_n)][t,q,ts]  <=  m[Symbol("dvHeatingProduction"*_n)][t,q,ts]
+                m[Symbol("dvProductionToWaste"*_n)][t,q,ts] + m[Symbol("dvHeatToAbsorptionChiller"*_n)][t,q,ts]  <=  m[Symbol("dvHeatingProduction"*_n)][t,q,ts]
             )
         end
     end

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -378,7 +378,7 @@ end
                                         include_cooling_in_size::Union{Bool,Nothing}=nothing)
 
 Depending on the set of inputs, different sets of outputs are determine in addition to all CHP cost and performance parameter defaults:
-    1. Inputs: hot_water_or_steam and avg_boiler_fuel_load_mmbtu_per_hour
+    1. Inputs: hot_water_or_steam and avg_boiler_fuel_load_mmbtu_per_hour or avg_cooling_load_kw with absorption_chiller_cop and include_cooling_in_size
        Outputs: prime_mover, size_class, chp_elec_size_heuristic_kw, chp_max_size_kw
     2. Inputs: prime_mover and avg_boiler_fuel_load_mmbtu_per_hour
        Outputs: size_class, chp_elec_size_heuristic_kw, chp_max_size_kw

--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -500,7 +500,7 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
                     year = electric_load.year,
                     sector = site.sector,
                     federal_procurement_type = site.federal_procurement_type)
-        else # Only if modeling CHP without heating_load and existing_boiler (for prime generator, electric-only)
+        else # Only if modeling CHP without heating_load and existing_boiler (for prime generator, electric-only, or only sending heat to absorption chiller)
             chp = CHP(d["CHP"];
                     electric_load_series_kw = electric_load.loads_kw,
                     avg_cooling_load_kw = avg_cooling_load_kw,

--- a/src/core/techs.jl
+++ b/src/core/techs.jl
@@ -337,13 +337,17 @@ function Techs(s::Scenario)
         append!(providing_oper_res, pvtechs)
     end
 
-    if sum(s.dhw_load.loads_kw) == 0.0
+    # Zero out can_serve_* lists when the corresponding load is zero,
+    # UNLESS AbsorptionChiller is using that heating quality as its heat source
+    # (in which case techs must remain available to supply heat to the AC even though direct load is zero).
+    ac_heating_load = !isnothing(s.absorption_chiller) ? s.absorption_chiller.heating_load_input : nothing
+    if sum(s.dhw_load.loads_kw) == 0.0 && ac_heating_load != "DomesticHotWater"
         techs_can_serve_dhw = String[]
     end
-    if sum(s.space_heating_load.loads_kw) == 0.0
+    if sum(s.space_heating_load.loads_kw) == 0.0 && ac_heating_load != "SpaceHeating"
         techs_can_serve_space_heating = String[]
     end
-    if sum(s.process_heat_load.loads_kw) == 0.0
+    if sum(s.process_heat_load.loads_kw) == 0.0 && ac_heating_load != "ProcessHeat"
         techs_can_serve_process_heat = String[]
     end
 


### PR DESCRIPTION
This pull request updates the handling of heating technologies and their interactions with absorption chillers, ensuring that heat supplied to absorption chillers is correctly accounted for in constraints and technology availability. The changes improve model accuracy when heating loads are zero but heat is still needed for cooling via absorption chillers.

**Constraint and Model Logic Improvements:**

* Modified heating technology constraints in `add_heating_tech_constraints` to include heat sent to absorption chillers (`dvHeatToAbsorptionChiller`) in the total heat output, ensuring that both waste heat and heat used for cooling are properly limited by total production. [[1]](diffhunk://#diff-fab0d4cbad0b6816855c79ef451343fbc007d0f5430a925159f675bb4bb456ffL47-R47) [[2]](diffhunk://#diff-fab0d4cbad0b6816855c79ef451343fbc007d0f5430a925159f675bb4bb456ffL59-R59)
* Updated logic in `Techs(s::Scenario)` to prevent removal of technologies from `can_serve_*` lists when the corresponding load is zero, if an absorption chiller is present and using that heat source. This ensures technologies remain available to supply heat to the absorption chiller even if direct load is absent.

**Documentation and Scenario Handling:**

* Clarified documentation in `chp.jl` to indicate that CHP sizing can also be based on cooling load with absorption chillers, not just heating loads.
* Updated scenario creation logic to clarify that CHP can be modeled for electric-only or for supplying heat exclusively to absorption chillers, even without direct heating loads or existing boilers.