### PR TITLE
include_cooling_in_chp_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## fix-chp-to-abschl
+### Fixed
+- Fixed an error in which the absorption chiller could not be included without a nonzero site heating load
+- Fixed a bug in dispatch of heat to absorption chiller from steam turbine and Hot TES
+### Changed
+- Renamed argument `include_cooling_in_chp_size` to `include_cooling_in_chp_size` within a few methods in `CHP`
+
 ## v0.59.0
 ### Added
 - Added two new size classes for **SteamTurbine** tech with new tech size ranges.

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -155,7 +155,7 @@ function CHP(d::Dict;
             electric_load_series_kw::Array{<:Real,1}=Real[],
             avg_cooling_load_kw::Union{Float64, Nothing}=nothing,
             absorption_chiller_cop::Union{Float64, Nothing}=nothing,
-            include_cooling_in_size::Bool=false,
+            include_cooling_in_chp_size::Bool=false,
             year::Int64=2017,
             sector::String,
             federal_procurement_type::String)
@@ -239,7 +239,7 @@ function CHP(d::Dict;
                                                                 thermal_efficiency=chp.thermal_efficiency_full_load,
                                                                 avg_cooling_load_kw=avg_cooling_load_kw,
                                                                 absorption_chiller_cop=absorption_chiller_cop,
-                                                                include_cooling_in_size=include_cooling_in_size)
+                                                                include_cooling_in_chp_size=include_cooling_in_chp_size)
     defaults = chp_defaults_response["default_inputs"]
     for (k, v) in custom_chp_inputs
         if k in [:installed_cost_per_kw, :tech_sizes_for_cost_curve]
@@ -375,7 +375,7 @@ end
                                         thermal_efficiency::Float64=NaN,
                                         avg_cooling_load_kw::Union{Float64,Nothing}=nothing,
                                         absorption_chiller_cop::Union{Float64,Nothing}=nothing,
-                                        include_cooling_in_size::Union{Bool,Nothing}=nothing)
+                                        include_cooling_in_chp_size::Union{Bool,Nothing}=nothing)
 
 Depending on the set of inputs, different sets of outputs are determine in addition to all CHP cost and performance parameter defaults:
     1. Inputs: hot_water_or_steam and avg_boiler_fuel_load_mmbtu_per_hour
@@ -402,7 +402,7 @@ for larger sizes and steam.
 
 The determination of size_class and defaults based only on the electric load metrics is for non-heating "CHP", a.k.a. Prime Generator
 
-Cooling load integration: When include_cooling_in_size is true, the CHP sizing heuristic accounts for both heating and 
+Cooling load integration: When include_cooling_in_chp_size is true, the CHP sizing heuristic accounts for both heating and 
 cooling loads (via absorption chiller). The avg_cooling_load_kw and absorption_chiller_cop parameters specify the cooling thermal load 
 and absorption chiller thermal COP to convert cooling load into equivalent thermal load for CHP sizing.
 """
@@ -418,7 +418,7 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
                                                 thermal_efficiency::Float64=NaN, 
                                                 avg_cooling_load_kw::Union{Float64,Nothing}=nothing,
                                                 absorption_chiller_cop::Union{Float64,Nothing}=nothing,
-                                                include_cooling_in_size::Union{Bool,Nothing}=nothing
+                                                include_cooling_in_chp_size::Union{Bool,Nothing}=nothing
                                                 )
     
     prime_mover_defaults_all = JSON.parsefile(joinpath(@__DIR__, "..", "..", "data", "chp", "chp_defaults.json"))
@@ -469,14 +469,14 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
     # and estimate max size based on 2x the heuristic size
     recalc_heuristic_flag = false
     boiler_effic = NaN
-    if isnothing(include_cooling_in_size)
+    if isnothing(include_cooling_in_chp_size)
         avg_cooling = 0.0
         abschl_cop = 1.0
         include_cooling = false
     else
         avg_cooling = isnothing(avg_cooling_load_kw) ? 0.0 : avg_cooling_load_kw
         abschl_cop = isnothing(absorption_chiller_cop) ? absorption_chiller_defaults_all[hot_water_or_steam]["cop_thermal"] : absorption_chiller_cop
-        include_cooling = include_cooling_in_size
+        include_cooling = include_cooling_in_chp_size
     end
     if !isnothing(avg_boiler_fuel_load_mmbtu_per_hour) && !is_electric_only
         if isnothing(prime_mover)
@@ -575,7 +575,7 @@ end
 
 function get_heuristic_chp_size_kw(prime_mover_defaults_all, avg_boiler_fuel_load_mmbtu_per_hour, 
                                 prime_mover, size_class, hot_water_or_steam, boiler_effic, thermal_efficiency=NaN,
-                                avg_cooling_load_kw=0.0, absorption_chiller_cop=1.0, include_cooling_in_size=false)
+                                avg_cooling_load_kw=0.0, absorption_chiller_cop=1.0, include_cooling_in_chp_size=false)
     if isnan(thermal_efficiency)
         therm_effic = prime_mover_defaults_all[prime_mover]["thermal_efficiency_full_load"][hot_water_or_steam][size_class+1]
     else
@@ -591,7 +591,7 @@ function get_heuristic_chp_size_kw(prime_mover_defaults_all, avg_boiler_fuel_loa
     elec_effic = prime_mover_defaults_all[prime_mover]["electric_efficiency_full_load"][size_class+1]
     avg_heating_thermal_load_mmbtu_per_hr = avg_boiler_fuel_load_mmbtu_per_hour * boiler_effic
     chp_fuel_rate_mmbtu_per_hr = avg_heating_thermal_load_mmbtu_per_hr / therm_effic
-    if include_cooling_in_size
+    if include_cooling_in_chp_size
         # Convert cooling load to heat consumption/load needed by absorption chiller, then to CHP fuel input
         avg_cooling_thermal_load_mmbtu_per_hr = avg_cooling_load_kw / (absorption_chiller_cop * KWH_PER_MMBTU)
         chp_fuel_rate_mmbtu_per_hr += avg_cooling_thermal_load_mmbtu_per_hr / therm_effic

--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -473,12 +473,12 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
         absorption_chiller_cop = nothing
         # User can override by explicitly setting include_cooling_in_chp_size = false
         if "include_cooling_in_chp_size" in keys(d["CHP"])
-            include_cooling_in_size = pop!(d["CHP"], "include_cooling_in_chp_size")
+            include_cooling_in_chp_size = pop!(d["CHP"], "include_cooling_in_chp_size")
         else
-            include_cooling_in_size = haskey(d, "AbsorptionChiller")
+            include_cooling_in_chp_size = haskey(d, "AbsorptionChiller")
         end
         
-        if max_cooling_demand_kw > 0 && include_cooling_in_size
+        if max_cooling_demand_kw > 0 && include_cooling_in_chp_size
             # Use already-processed cooling_load object
             avg_cooling_load_kw = sum(cooling_load.loads_kw_thermal) / length(cooling_load.loads_kw_thermal)
             # Get absorption chiller COP if specified, otherwise will use default
@@ -496,7 +496,7 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
                     electric_load_series_kw = electric_load.loads_kw,
                     avg_cooling_load_kw = avg_cooling_load_kw,
                     absorption_chiller_cop = absorption_chiller_cop,
-                    include_cooling_in_size = include_cooling_in_size,
+                    include_cooling_in_chp_size = include_cooling_in_chp_size,
                     year = electric_load.year,
                     sector = site.sector,
                     federal_procurement_type = site.federal_procurement_type)
@@ -505,7 +505,7 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
                     electric_load_series_kw = electric_load.loads_kw,
                     avg_cooling_load_kw = avg_cooling_load_kw,
                     absorption_chiller_cop = absorption_chiller_cop,
-                    include_cooling_in_size = include_cooling_in_size,
+                    include_cooling_in_chp_size = include_cooling_in_chp_size,
                     year = electric_load.year,
                     sector = site.sector,
                     federal_procurement_type = site.federal_procurement_type)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,7 +224,7 @@ else  # run HiGHS tests
             thermal_efficiency = NaN
             avg_cooling_load_kw = nothing
             absorption_chiller_cop = nothing
-            include_cooling_in_size = nothing
+            include_cooling_in_chp_size = nothing
             #Case 1: electric only
             response = get_chp_defaults_prime_mover_size_class(;hot_water_or_steam=hot_water_or_steam,
                                             avg_boiler_fuel_load_mmbtu_per_hour=avg_boiler_fuel_load_mmbtu_per_hour,
@@ -238,7 +238,7 @@ else  # run HiGHS tests
                                             thermal_efficiency=thermal_efficiency,
                                             avg_cooling_load_kw=avg_cooling_load_kw,
                                             absorption_chiller_cop=absorption_chiller_cop,
-                                            include_cooling_in_size=include_cooling_in_size
+                                            include_cooling_in_chp_size=include_cooling_in_chp_size
                                             )
             @test response["chp_elec_size_heuristic_kw"] ≈ 100.0 atol=1e-3
             @test response["chp_max_size_kw"] ≈ 200.0 atol=1e-3
@@ -260,7 +260,7 @@ else  # run HiGHS tests
                                             thermal_efficiency=thermal_efficiency,
                                             avg_cooling_load_kw=avg_cooling_load_kw,
                                             absorption_chiller_cop=absorption_chiller_cop,
-                                            include_cooling_in_size=include_cooling_in_size
+                                            include_cooling_in_chp_size=include_cooling_in_chp_size
                                             )
             @test response["chp_elec_size_heuristic_kw"] ≈ 65.0 atol=0.1
             @test response["chp_max_size_kw"] ≈ 130.0 atol=0.2
@@ -268,7 +268,7 @@ else  # run HiGHS tests
             #Case 3: heating + cooling via absorption chiller only (low electric load)
             avg_cooling_load_kw = 100.0
             absorption_chiller_cop = 1.0
-            include_cooling_in_size = true
+            include_cooling_in_chp_size = true
 
             response = get_chp_defaults_prime_mover_size_class(;hot_water_or_steam=hot_water_or_steam,
                                             avg_boiler_fuel_load_mmbtu_per_hour=avg_boiler_fuel_load_mmbtu_per_hour,
@@ -282,7 +282,7 @@ else  # run HiGHS tests
                                             thermal_efficiency=thermal_efficiency,
                                             avg_cooling_load_kw=avg_cooling_load_kw,
                                             absorption_chiller_cop=absorption_chiller_cop,
-                                            include_cooling_in_size=include_cooling_in_size
+                                            include_cooling_in_chp_size=include_cooling_in_chp_size
                                             )
             @test response["chp_elec_size_heuristic_kw"] ≈ 146.2 atol=0.1
             @test response["chp_max_size_kw"] ≈ 146.2*2 atol=0.2
@@ -335,7 +335,7 @@ else  # run HiGHS tests
                                             thermal_efficiency=thermal_efficiency,
                                             avg_cooling_load_kw=avg_cooling_load_kw,
                                             absorption_chiller_cop=absorption_chiller_cop,
-                                            include_cooling_in_size=include_cooling_in_size
+                                            include_cooling_in_chp_size=include_cooling_in_chp_size
                                             )
             @test response["chp_elec_size_heuristic_kw"] ≈ case3_max_size_kw / 2 atol=0.1
             @test response["chp_max_size_kw"] ≈ case3_max_size_kw atol=0.1


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Docs have been added / updated if applicable
- [x] Any new packages have been added to the [compat] section of Project.toml
- [x] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
- [x] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
- [X] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API

### Changed
- Renamed argument `include_cooling_in_chp_size` to `include_cooling_in_chp_size` within a few methods in `CHP`