### PR TITLE
V0.59.1 Fixes to Dispatch of Heat to Absorption Chiller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## fix-chp-to-abschl
+### Fixed
+- `constraints/thermal_tech_constraints.jl`: In `add_heating_tech_constraints`, updated waste heat constraints to include **dvHeatToAbsorptionChiller** in the total heat output, so that `dvProductionToWaste + dvHeatToAbsorptionChiller <= dvHeatingProduction`. Previously, heat dispatched to the absorption chiller was unconstrained by total production.
+- `core/techs.jl`: In `Techs(s::Scenario)`, prevented zeroing out `can_serve_dhw`, `can_serve_space_heating`, and `can_serve_process_heat` technology lists when the corresponding direct load is zero, if an **AbsorptionChiller** is using that heating quality as its heat source. This ensures heating technologies remain available to supply heat to the absorption chiller even when no direct heating load exists.
+
 ## v0.59.0
 ### Added
 - Added two new size classes for **SteamTurbine** tech with new tech size ranges.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## fix-chp-to-abschl
+### Fixed
+- Fixed an error in which the absorption chiller could not be included without a nonzero site heating load
+- Fixed a bug in dispatch of heat to absorption chiller from steam turbine and Hot TES
+### Changed
+- Renamed argument `include_cooling_in_chp_size` to `include_cooling_in_chp_size` within a few methods in `CHP`
+
 ## v0.59.0
 ### Added
 - Added two new size classes for **SteamTurbine** tech with new tech size ranges.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,10 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
-## fix-chp-to-abschl
+## v0.59.1
 ### Fixed
 - `constraints/thermal_tech_constraints.jl`: In `add_heating_tech_constraints`, updated waste heat constraints to include **dvHeatToAbsorptionChiller** in the total heat output, so that `dvProductionToWaste + dvHeatToAbsorptionChiller <= dvHeatingProduction`. Previously, heat dispatched to the absorption chiller was unconstrained by total production.
 - `core/techs.jl`: In `Techs(s::Scenario)`, prevented zeroing out `can_serve_dhw`, `can_serve_space_heating`, and `can_serve_process_heat` technology lists when the corresponding direct load is zero, if an **AbsorptionChiller** is using that heating quality as its heat source. This ensures heating technologies remain available to supply heat to the absorption chiller even when no direct heating load exists.
-
 ### Changed
 - Renamed argument `include_cooling_in_chp_size` to `include_cooling_in_chp_size` within a few methods in `CHP`
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "REopt"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
 authors = ["Nick Laws", "Hallie Dunham <hallie.dunham@nlr.gov>", "Bill Becker <william.becker@nlr.gov>", "Bhavesh Rathod <bhavesh.rathod@nlr.gov>", "Alex Zolan <alexander.zolan@nlr.gov>", "Amanda Farthing <amanda.farthing@nlr.gov>", "Xiangkun Li <xiangkun.li@nlr.gov>", "An Pham <an.pham@nlr.gov>", "Byron Pullutasig <byron.pullatasig@nlr.gov>"]
-version = "0.59.0"
+version = "0.59.1"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/constraints/thermal_tech_constraints.jl
+++ b/src/constraints/thermal_tech_constraints.jl
@@ -44,7 +44,7 @@ function add_heating_tech_constraints(m, p; _n="")
             )
             if !isempty(setdiff(union(p.techs.heating, p.techs.chp),p.techs.can_supply_steam_turbine))
                 @constraint(m, [t in setdiff(union(p.techs.heating,p.techs.chp),p.techs.can_supply_steam_turbine), q in p.heating_loads, ts in p.time_steps],
-                    m[Symbol("dvProductionToWaste"*_n)][t,q,ts]  <=  m[Symbol("dvHeatingProduction"*_n)][t,q,ts]
+                    m[Symbol("dvProductionToWaste"*_n)][t,q,ts] + m[Symbol("dvHeatToAbsorptionChiller"*_n)][t,q,ts]  <=  m[Symbol("dvHeatingProduction"*_n)][t,q,ts]
                 )
             end
         end
@@ -56,7 +56,7 @@ function add_heating_tech_constraints(m, p; _n="")
             )
         else
             @constraint(m, [t in union(p.techs.heating, p.techs.chp), q in p.heating_loads, ts in p.time_steps],
-                m[Symbol("dvProductionToWaste"*_n)][t,q,ts]  <=  m[Symbol("dvHeatingProduction"*_n)][t,q,ts]
+                m[Symbol("dvProductionToWaste"*_n)][t,q,ts] + m[Symbol("dvHeatToAbsorptionChiller"*_n)][t,q,ts]  <=  m[Symbol("dvHeatingProduction"*_n)][t,q,ts]
             )
         end
     end

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -378,7 +378,7 @@ end
                                         include_cooling_in_size::Union{Bool,Nothing}=nothing)
 
 Depending on the set of inputs, different sets of outputs are determine in addition to all CHP cost and performance parameter defaults:
-    1. Inputs: hot_water_or_steam and avg_boiler_fuel_load_mmbtu_per_hour
+    1. Inputs: hot_water_or_steam and avg_boiler_fuel_load_mmbtu_per_hour or avg_cooling_load_kw with absorption_chiller_cop and include_cooling_in_size
        Outputs: prime_mover, size_class, chp_elec_size_heuristic_kw, chp_max_size_kw
     2. Inputs: prime_mover and avg_boiler_fuel_load_mmbtu_per_hour
        Outputs: size_class, chp_elec_size_heuristic_kw, chp_max_size_kw

--- a/src/core/chp.jl
+++ b/src/core/chp.jl
@@ -155,7 +155,7 @@ function CHP(d::Dict;
             electric_load_series_kw::Array{<:Real,1}=Real[],
             avg_cooling_load_kw::Union{Float64, Nothing}=nothing,
             absorption_chiller_cop::Union{Float64, Nothing}=nothing,
-            include_cooling_in_size::Bool=false,
+            include_cooling_in_chp_size::Bool=false,
             year::Int64=2017,
             sector::String,
             federal_procurement_type::String)
@@ -239,7 +239,7 @@ function CHP(d::Dict;
                                                                 thermal_efficiency=chp.thermal_efficiency_full_load,
                                                                 avg_cooling_load_kw=avg_cooling_load_kw,
                                                                 absorption_chiller_cop=absorption_chiller_cop,
-                                                                include_cooling_in_size=include_cooling_in_size)
+                                                                include_cooling_in_chp_size=include_cooling_in_chp_size)
     defaults = chp_defaults_response["default_inputs"]
     for (k, v) in custom_chp_inputs
         if k in [:installed_cost_per_kw, :tech_sizes_for_cost_curve]
@@ -375,7 +375,7 @@ end
                                         thermal_efficiency::Float64=NaN,
                                         avg_cooling_load_kw::Union{Float64,Nothing}=nothing,
                                         absorption_chiller_cop::Union{Float64,Nothing}=nothing,
-                                        include_cooling_in_size::Union{Bool,Nothing}=nothing)
+                                        include_cooling_in_chp_size::Union{Bool,Nothing}=nothing)
 
 Depending on the set of inputs, different sets of outputs are determine in addition to all CHP cost and performance parameter defaults:
     1. Inputs: hot_water_or_steam and avg_boiler_fuel_load_mmbtu_per_hour
@@ -402,7 +402,7 @@ for larger sizes and steam.
 
 The determination of size_class and defaults based only on the electric load metrics is for non-heating "CHP", a.k.a. Prime Generator
 
-Cooling load integration: When include_cooling_in_size is true, the CHP sizing heuristic accounts for both heating and 
+Cooling load integration: When include_cooling_in_chp_size is true, the CHP sizing heuristic accounts for both heating and 
 cooling loads (via absorption chiller). The avg_cooling_load_kw and absorption_chiller_cop parameters specify the cooling thermal load 
 and absorption chiller thermal COP to convert cooling load into equivalent thermal load for CHP sizing.
 """
@@ -418,7 +418,7 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
                                                 thermal_efficiency::Float64=NaN, 
                                                 avg_cooling_load_kw::Union{Float64,Nothing}=nothing,
                                                 absorption_chiller_cop::Union{Float64,Nothing}=nothing,
-                                                include_cooling_in_size::Union{Bool,Nothing}=nothing
+                                                include_cooling_in_chp_size::Union{Bool,Nothing}=nothing
                                                 )
     
     prime_mover_defaults_all = JSON.parsefile(joinpath(@__DIR__, "..", "..", "data", "chp", "chp_defaults.json"))
@@ -469,14 +469,14 @@ function get_chp_defaults_prime_mover_size_class(;hot_water_or_steam::Union{Stri
     # and estimate max size based on 2x the heuristic size
     recalc_heuristic_flag = false
     boiler_effic = NaN
-    if isnothing(include_cooling_in_size)
+    if isnothing(include_cooling_in_chp_size)
         avg_cooling = 0.0
         abschl_cop = 1.0
         include_cooling = false
     else
         avg_cooling = isnothing(avg_cooling_load_kw) ? 0.0 : avg_cooling_load_kw
         abschl_cop = isnothing(absorption_chiller_cop) ? absorption_chiller_defaults_all[hot_water_or_steam]["cop_thermal"] : absorption_chiller_cop
-        include_cooling = include_cooling_in_size
+        include_cooling = include_cooling_in_chp_size
     end
     if !isnothing(avg_boiler_fuel_load_mmbtu_per_hour) && !is_electric_only
         if isnothing(prime_mover)
@@ -575,7 +575,7 @@ end
 
 function get_heuristic_chp_size_kw(prime_mover_defaults_all, avg_boiler_fuel_load_mmbtu_per_hour, 
                                 prime_mover, size_class, hot_water_or_steam, boiler_effic, thermal_efficiency=NaN,
-                                avg_cooling_load_kw=0.0, absorption_chiller_cop=1.0, include_cooling_in_size=false)
+                                avg_cooling_load_kw=0.0, absorption_chiller_cop=1.0, include_cooling_in_chp_size=false)
     if isnan(thermal_efficiency)
         therm_effic = prime_mover_defaults_all[prime_mover]["thermal_efficiency_full_load"][hot_water_or_steam][size_class+1]
     else
@@ -591,7 +591,7 @@ function get_heuristic_chp_size_kw(prime_mover_defaults_all, avg_boiler_fuel_loa
     elec_effic = prime_mover_defaults_all[prime_mover]["electric_efficiency_full_load"][size_class+1]
     avg_heating_thermal_load_mmbtu_per_hr = avg_boiler_fuel_load_mmbtu_per_hour * boiler_effic
     chp_fuel_rate_mmbtu_per_hr = avg_heating_thermal_load_mmbtu_per_hr / therm_effic
-    if include_cooling_in_size
+    if include_cooling_in_chp_size
         # Convert cooling load to heat consumption/load needed by absorption chiller, then to CHP fuel input
         avg_cooling_thermal_load_mmbtu_per_hr = avg_cooling_load_kw / (absorption_chiller_cop * KWH_PER_MMBTU)
         chp_fuel_rate_mmbtu_per_hr += avg_cooling_thermal_load_mmbtu_per_hr / therm_effic

--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -473,12 +473,12 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
         absorption_chiller_cop = nothing
         # User can override by explicitly setting include_cooling_in_chp_size = false
         if "include_cooling_in_chp_size" in keys(d["CHP"])
-            include_cooling_in_size = pop!(d["CHP"], "include_cooling_in_chp_size")
+            include_cooling_in_chp_size = pop!(d["CHP"], "include_cooling_in_chp_size")
         else
-            include_cooling_in_size = haskey(d, "AbsorptionChiller")
+            include_cooling_in_chp_size = haskey(d, "AbsorptionChiller")
         end
         
-        if max_cooling_demand_kw > 0 && include_cooling_in_size
+        if max_cooling_demand_kw > 0 && include_cooling_in_chp_size
             # Use already-processed cooling_load object
             avg_cooling_load_kw = sum(cooling_load.loads_kw_thermal) / length(cooling_load.loads_kw_thermal)
             # Get absorption chiller COP if specified, otherwise will use default
@@ -496,7 +496,7 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
                     electric_load_series_kw = electric_load.loads_kw,
                     avg_cooling_load_kw = avg_cooling_load_kw,
                     absorption_chiller_cop = absorption_chiller_cop,
-                    include_cooling_in_size = include_cooling_in_size,
+                    include_cooling_in_chp_size = include_cooling_in_chp_size,
                     year = electric_load.year,
                     sector = site.sector,
                     federal_procurement_type = site.federal_procurement_type)
@@ -505,7 +505,7 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
                     electric_load_series_kw = electric_load.loads_kw,
                     avg_cooling_load_kw = avg_cooling_load_kw,
                     absorption_chiller_cop = absorption_chiller_cop,
-                    include_cooling_in_size = include_cooling_in_size,
+                    include_cooling_in_chp_size = include_cooling_in_chp_size,
                     year = electric_load.year,
                     sector = site.sector,
                     federal_procurement_type = site.federal_procurement_type)

--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -500,7 +500,7 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
                     year = electric_load.year,
                     sector = site.sector,
                     federal_procurement_type = site.federal_procurement_type)
-        else # Only if modeling CHP without heating_load and existing_boiler (for prime generator, electric-only)
+        else # Only if modeling CHP without heating_load and existing_boiler (for prime generator, electric-only, or only sending heat to absorption chiller)
             chp = CHP(d["CHP"];
                     electric_load_series_kw = electric_load.loads_kw,
                     avg_cooling_load_kw = avg_cooling_load_kw,

--- a/src/core/techs.jl
+++ b/src/core/techs.jl
@@ -337,13 +337,17 @@ function Techs(s::Scenario)
         append!(providing_oper_res, pvtechs)
     end
 
-    if sum(s.dhw_load.loads_kw) == 0.0
+    # Zero out can_serve_* lists when the corresponding load is zero,
+    # UNLESS AbsorptionChiller is using that heating quality as its heat source
+    # (in which case techs must remain available to supply heat to the AC even though direct load is zero).
+    ac_heating_load = !isnothing(s.absorption_chiller) ? s.absorption_chiller.heating_load_input : nothing
+    if sum(s.dhw_load.loads_kw) == 0.0 && ac_heating_load != "DomesticHotWater"
         techs_can_serve_dhw = String[]
     end
-    if sum(s.space_heating_load.loads_kw) == 0.0
+    if sum(s.space_heating_load.loads_kw) == 0.0 && ac_heating_load != "SpaceHeating"
         techs_can_serve_space_heating = String[]
     end
-    if sum(s.process_heat_load.loads_kw) == 0.0
+    if sum(s.process_heat_load.loads_kw) == 0.0 && ac_heating_load != "ProcessHeat"
         techs_can_serve_process_heat = String[]
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,7 +224,7 @@ else  # run HiGHS tests
             thermal_efficiency = NaN
             avg_cooling_load_kw = nothing
             absorption_chiller_cop = nothing
-            include_cooling_in_size = nothing
+            include_cooling_in_chp_size = nothing
             #Case 1: electric only
             response = get_chp_defaults_prime_mover_size_class(;hot_water_or_steam=hot_water_or_steam,
                                             avg_boiler_fuel_load_mmbtu_per_hour=avg_boiler_fuel_load_mmbtu_per_hour,
@@ -238,7 +238,7 @@ else  # run HiGHS tests
                                             thermal_efficiency=thermal_efficiency,
                                             avg_cooling_load_kw=avg_cooling_load_kw,
                                             absorption_chiller_cop=absorption_chiller_cop,
-                                            include_cooling_in_size=include_cooling_in_size
+                                            include_cooling_in_chp_size=include_cooling_in_chp_size
                                             )
             @test response["chp_elec_size_heuristic_kw"] ≈ 100.0 atol=1e-3
             @test response["chp_max_size_kw"] ≈ 200.0 atol=1e-3
@@ -260,7 +260,7 @@ else  # run HiGHS tests
                                             thermal_efficiency=thermal_efficiency,
                                             avg_cooling_load_kw=avg_cooling_load_kw,
                                             absorption_chiller_cop=absorption_chiller_cop,
-                                            include_cooling_in_size=include_cooling_in_size
+                                            include_cooling_in_chp_size=include_cooling_in_chp_size
                                             )
             @test response["chp_elec_size_heuristic_kw"] ≈ 65.0 atol=0.1
             @test response["chp_max_size_kw"] ≈ 130.0 atol=0.2
@@ -268,7 +268,7 @@ else  # run HiGHS tests
             #Case 3: heating + cooling via absorption chiller only (low electric load)
             avg_cooling_load_kw = 100.0
             absorption_chiller_cop = 1.0
-            include_cooling_in_size = true
+            include_cooling_in_chp_size = true
 
             response = get_chp_defaults_prime_mover_size_class(;hot_water_or_steam=hot_water_or_steam,
                                             avg_boiler_fuel_load_mmbtu_per_hour=avg_boiler_fuel_load_mmbtu_per_hour,
@@ -282,7 +282,7 @@ else  # run HiGHS tests
                                             thermal_efficiency=thermal_efficiency,
                                             avg_cooling_load_kw=avg_cooling_load_kw,
                                             absorption_chiller_cop=absorption_chiller_cop,
-                                            include_cooling_in_size=include_cooling_in_size
+                                            include_cooling_in_chp_size=include_cooling_in_chp_size
                                             )
             @test response["chp_elec_size_heuristic_kw"] ≈ 146.2 atol=0.1
             @test response["chp_max_size_kw"] ≈ 146.2*2 atol=0.2
@@ -335,7 +335,7 @@ else  # run HiGHS tests
                                             thermal_efficiency=thermal_efficiency,
                                             avg_cooling_load_kw=avg_cooling_load_kw,
                                             absorption_chiller_cop=absorption_chiller_cop,
-                                            include_cooling_in_size=include_cooling_in_size
+                                            include_cooling_in_chp_size=include_cooling_in_chp_size
                                             )
             @test response["chp_elec_size_heuristic_kw"] ≈ case3_max_size_kw / 2 atol=0.1
             @test response["chp_max_size_kw"] ≈ case3_max_size_kw atol=0.1


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Docs have been added / updated if applicable
- [x] Any new packages have been added to the [compat] section of Project.toml
- [x] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
- [x] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
- [x] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API

### Fixed
- `constraints/thermal_tech_constraints.jl`: In `add_heating_tech_constraints`, updated waste heat constraints to include **dvHeatToAbsorptionChiller** in the total heat output, so that `dvProductionToWaste + dvHeatToAbsorptionChiller <= dvHeatingProduction`. Previously, heat dispatched to the absorption chiller was unconstrained by total production.
- `core/techs.jl`: In `Techs(s::Scenario)`, prevented zeroing out `can_serve_dhw`, `can_serve_space_heating`, and `can_serve_process_heat` technology lists when the corresponding direct load is zero, if an **AbsorptionChiller** is using that heating quality as its heat source. This ensures heating technologies remain available to supply heat to the absorption chiller even when no direct heating load exists.

### Changed
- Renamed argument `include_cooling_in_chp_size` to `include_cooling_in_chp_size` within a few methods in `CHP`